### PR TITLE
fix(subscriptions): respect billing cycle when computing totals (#84)

### DIFF
--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
@@ -744,8 +744,8 @@ private fun PaymentStatusBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 40.dp),
+                .padding(horizontal = Spacing.lg)
+                .padding(bottom = Spacing.xl + Spacing.sm),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Box(
@@ -764,7 +764,7 @@ private fun PaymentStatusBottomSheet(
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(0.5f))
                         .clickable { onEdit() }
-                        .padding(8.dp)
+                        .padding(Spacing.sm)
                 ) {
                     Icon(
                         imageVector =Iconax.Edit2,
@@ -775,8 +775,8 @@ private fun PaymentStatusBottomSheet(
                 }
             }
             
-            Spacer(modifier = Modifier.height(16.dp))
-            
+            Spacer(modifier = Modifier.height(Spacing.md))
+
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(
@@ -785,8 +785,8 @@ private fun PaymentStatusBottomSheet(
                 shape = MaterialTheme.shapes.large
             ) {
                 Row(
-                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.padding(Spacing.md).fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.md),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     BrandIcon(
@@ -815,19 +815,17 @@ private fun PaymentStatusBottomSheet(
                             fontWeight = FontWeight.Bold,
                             color = if (isOverdue) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onSecondaryContainer
                         )
-                        val cycleLabel = SubscriptionUtils.formatBillingCycle(subscription.billingCycle)
                         val displayAmount = convertedAmount ?: subscription.amount
                         val displayCurrency = if (convertedAmount != null) {
                             targetCurrency ?: subscription.currency
                         } else {
                             subscription.currency
                         }
-                        val monthlyEq = SubscriptionUtils.monthlyEquivalent(displayAmount, subscription.billingCycle)
-                        val cycleSubtitle = if (monthlyEq.compareTo(displayAmount) == 0) {
-                            cycleLabel
-                        } else {
-                            "$cycleLabel · ≈ ${CurrencyFormatter.formatCurrency(monthlyEq, displayCurrency)}/mo"
-                        }
+                        val cycleSubtitle = SubscriptionUtils.cycleSubtitle(
+                            amount = displayAmount,
+                            currency = displayCurrency,
+                            billingCycle = subscription.billingCycle
+                        )
                         Text(
                             text = cycleSubtitle,
                             style = MaterialTheme.typography.bodySmall,
@@ -847,19 +845,19 @@ private fun PaymentStatusBottomSheet(
                 }
             }
             
-            Spacer(modifier = Modifier.height(24.dp))
-            
+            Spacer(modifier = Modifier.height(Spacing.lg))
+
             Text(
                 text = "Is this subscription paid?",
                 style = MaterialTheme.typography.bodyLarge,
                 textAlign = TextAlign.Center
             )
-            
-            Spacer(modifier = Modifier.height(24.dp))
-            
+
+            Spacer(modifier = Modifier.height(Spacing.lg))
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
+                horizontalArrangement = Arrangement.spacedBy(Spacing.md)
             ) {
                 OutlinedButton(
                     onClick = onDismiss,
@@ -877,8 +875,8 @@ private fun PaymentStatusBottomSheet(
             }
             
             if (!subscription.smsBody.isNullOrBlank()) {
-                Spacer(modifier = Modifier.height(24.dp))
-                
+                Spacer(modifier = Modifier.height(Spacing.lg))
+
                 TextButton(
                     onClick = { showSmsBody = !showSmsBody }
                 ) {
@@ -887,13 +885,13 @@ private fun PaymentStatusBottomSheet(
                             imageVector = if (showSmsBody) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
                             contentDescription = null
                         )
-                        Spacer(modifier = Modifier.width(8.dp))
+                        Spacer(modifier = Modifier.width(Spacing.sm))
                         Text(if (showSmsBody) "Hide Original Message" else "Show Original Message")
                     }
                 }
-                
+
                 if (showSmsBody) {
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(Spacing.sm))
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
                         color = MaterialTheme.colorScheme.surfaceVariant,

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
@@ -99,6 +99,7 @@ import com.ritesh.cashiro.presentation.ui.theme.Spacing
 import com.ritesh.cashiro.presentation.ui.theme.expense_dark
 import com.ritesh.cashiro.presentation.ui.theme.expense_light
 import com.ritesh.cashiro.utils.CurrencyFormatter
+import com.ritesh.cashiro.utils.SubscriptionUtils
 import com.ritesh.cashiro.utils.formatAmount
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
@@ -596,6 +597,12 @@ private fun SwipeableSubscriptionItem(
                                     )
                                 }
 
+                                // Billing Cycle Tag
+                                SubtitleTag(
+                                    text = SubscriptionUtils.formatBillingCycle(subscription.billingCycle),
+                                    color = MaterialTheme.colorScheme.tertiary
+                                )
+
                                 // Category Tag
                                 categoryEntity?.let { category ->
                                     SubtitleTag(
@@ -791,6 +798,19 @@ private fun PaymentStatusBottomSheet(
                             style = MaterialTheme.typography.headlineMedium,
                             fontWeight = FontWeight.Bold,
                             color = if (isOverdue) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                        val cycleLabel = SubscriptionUtils.formatBillingCycle(subscription.billingCycle)
+                        val monthlyEq = SubscriptionUtils.monthlyEquivalent(subscription.amount, subscription.billingCycle)
+                        val cycleSubtitle = if (monthlyEq.compareTo(subscription.amount) == 0) {
+                            cycleLabel
+                        } else {
+                            "$cycleLabel · ≈ ${CurrencyFormatter.formatCurrency(monthlyEq, subscription.currency)}/mo"
+                        }
+                        Text(
+                            text = cycleSubtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (isOverdue) MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f)
+                                    else MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f)
                         )
                         if (subscription.nextPaymentDate != null) {
                             Text(

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
@@ -817,7 +817,11 @@ private fun PaymentStatusBottomSheet(
                         )
                         val cycleLabel = SubscriptionUtils.formatBillingCycle(subscription.billingCycle)
                         val displayAmount = convertedAmount ?: subscription.amount
-                        val displayCurrency = targetCurrency ?: subscription.currency
+                        val displayCurrency = if (convertedAmount != null) {
+                            targetCurrency ?: subscription.currency
+                        } else {
+                            subscription.currency
+                        }
                         val monthlyEq = SubscriptionUtils.monthlyEquivalent(displayAmount, subscription.billingCycle)
                         val cycleSubtitle = if (monthlyEq.compareTo(displayAmount) == 0) {
                             cycleLabel

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsScreen.kt
@@ -211,6 +211,8 @@ fun SubscriptionsScreen(
                 subscription = selectedSubscription,
                 categoryEntity = categoriesMap[selectedSubscription.category],
                 subcategoryEntity = subcategoriesMap[selectedSubscription.subcategory],
+                convertedAmount = uiState.convertedAmounts[selectedSubscription.id],
+                targetCurrency = uiState.targetCurrency,
                 onDismiss = { subscriptionsViewModel.selectSubscription(null) },
                 onMarkAsPaid = { subscriptionsViewModel.markAsPaid(selectedSubscription) },
                 onEdit = {
@@ -240,7 +242,8 @@ fun SubscriptionsScreen(
                     monthlyAmount = uiState.totalMonthlyAmount,
                     yearlyAmount = uiState.totalYearlyAmount,
                     activeCount = uiState.activeSubscriptions.size,
-                    currency = uiState.targetCurrency
+                    currency = uiState.targetCurrency,
+                    conversionFailureCount = uiState.conversionFailureCount
                 )
             }
             
@@ -300,7 +303,8 @@ private fun TotalSubscriptionsSummary(
     monthlyAmount: BigDecimal,
     yearlyAmount: BigDecimal,
     activeCount: Int,
-    currency: String
+    currency: String,
+    conversionFailureCount: Int = 0
 ) {
     CashiroCard(
         modifier = Modifier.fillMaxWidth(),
@@ -416,6 +420,16 @@ private fun TotalSubscriptionsSummary(
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
+            }
+            if (conversionFailureCount > 0) {
+                Spacer(modifier = Modifier.height(Spacing.sm))
+                Text(
+                    text = "$conversionFailureCount subscription(s) couldn't be converted to $currency, totals may be incomplete.",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         }
     }
@@ -710,6 +724,8 @@ private fun PaymentStatusBottomSheet(
     subscription: SubscriptionEntity,
     categoryEntity: CategoryEntity? = null,
     subcategoryEntity: SubcategoryEntity? = null,
+    convertedAmount: BigDecimal? = null,
+    targetCurrency: String? = null,
     onDismiss: () -> Unit,
     onMarkAsPaid: () -> Unit,
     onEdit: () -> Unit
@@ -800,11 +816,13 @@ private fun PaymentStatusBottomSheet(
                             color = if (isOverdue) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onSecondaryContainer
                         )
                         val cycleLabel = SubscriptionUtils.formatBillingCycle(subscription.billingCycle)
-                        val monthlyEq = SubscriptionUtils.monthlyEquivalent(subscription.amount, subscription.billingCycle)
-                        val cycleSubtitle = if (monthlyEq.compareTo(subscription.amount) == 0) {
+                        val displayAmount = convertedAmount ?: subscription.amount
+                        val displayCurrency = targetCurrency ?: subscription.currency
+                        val monthlyEq = SubscriptionUtils.monthlyEquivalent(displayAmount, subscription.billingCycle)
+                        val cycleSubtitle = if (monthlyEq.compareTo(displayAmount) == 0) {
                             cycleLabel
                         } else {
-                            "$cycleLabel · ≈ ${CurrencyFormatter.formatCurrency(monthlyEq, subscription.currency)}/mo"
+                            "$cycleLabel · ≈ ${CurrencyFormatter.formatCurrency(monthlyEq, displayCurrency)}/mo"
                         }
                         Text(
                             text = cycleSubtitle,

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsState.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsState.kt
@@ -11,5 +11,6 @@ data class SubscriptionsUiState(
     val isLoading: Boolean = true,
     val lastHiddenSubscription: SubscriptionEntity? = null,
     val selectedSubscription: SubscriptionEntity? = null,
-    val convertedAmounts: Map<Long, BigDecimal> = emptyMap()
+    val convertedAmounts: Map<Long, BigDecimal> = emptyMap(),
+    val conversionFailureCount: Int = 0
 )

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsViewModel.kt
@@ -67,6 +67,7 @@ class SubscriptionsViewModel @Inject constructor(
                 }
 
                 var totalMonthlyAmount = BigDecimal.ZERO
+                var conversionFailures = 0
                 val convertedAmounts = buildMap(subscriptions.size) {
                     subscriptions.forEach { sub ->
                         val converted = if (sub.currency == targetCurrency) {
@@ -76,7 +77,11 @@ class SubscriptionsViewModel @Inject constructor(
                                 amount = sub.amount,
                                 fromCurrency = sub.currency,
                                 toCurrency = targetCurrency
-                            ) ?: sub.amount
+                            )
+                        }
+                        if (converted == null) {
+                            conversionFailures++
+                            return@forEach
                         }
                         put(sub.id, converted)
                         totalMonthlyAmount = totalMonthlyAmount.add(
@@ -92,6 +97,7 @@ class SubscriptionsViewModel @Inject constructor(
                         totalYearlyAmount = totalMonthlyAmount.multiply(BigDecimal(12)),
                         targetCurrency = targetCurrency,
                         convertedAmounts = convertedAmounts,
+                        conversionFailureCount = conversionFailures,
                         isLoading = false
                     )
                 }

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/subscriptions/SubscriptionsViewModel.kt
@@ -66,25 +66,30 @@ class SubscriptionsViewModel @Inject constructor(
                     currencyConversionService.refreshExchangeRatesForAccount(subscriptionCurrencies + targetCurrency)
                 }
 
-                val convertedAmounts = subscriptions.associate { subscription ->
-                    subscription.id to if (subscription.currency == targetCurrency) {
-                        subscription.amount
-                    } else {
-                        currencyConversionService.convertAmount(
-                            amount = subscription.amount,
-                            fromCurrency = subscription.currency,
-                            toCurrency = targetCurrency
-                        ) ?: subscription.amount
+                var totalMonthlyAmount = BigDecimal.ZERO
+                val convertedAmounts = buildMap(subscriptions.size) {
+                    subscriptions.forEach { sub ->
+                        val converted = if (sub.currency == targetCurrency) {
+                            sub.amount
+                        } else {
+                            currencyConversionService.convertAmount(
+                                amount = sub.amount,
+                                fromCurrency = sub.currency,
+                                toCurrency = targetCurrency
+                            ) ?: sub.amount
+                        }
+                        put(sub.id, converted)
+                        totalMonthlyAmount = totalMonthlyAmount.add(
+                            SubscriptionUtils.monthlyEquivalent(converted, sub.billingCycle)
+                        )
                     }
                 }
 
-                val totalMonthlyAmount = convertedAmounts.values.sumOf { it }
-                
-                _uiState.update { 
+                _uiState.update {
                     it.copy(
                         activeSubscriptions = subscriptions,
                         totalMonthlyAmount = totalMonthlyAmount,
-                        totalYearlyAmount = totalMonthlyAmount * BigDecimal(12),
+                        totalYearlyAmount = totalMonthlyAmount.multiply(BigDecimal(12)),
                         targetCurrency = targetCurrency,
                         convertedAmounts = convertedAmounts,
                         isLoading = false

--- a/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
+++ b/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
@@ -17,10 +17,10 @@ object SubscriptionUtils {
 
     private data class CustomCycle(val count: Long, val unit: String, val endDate: String?)
 
-    private fun parseCustomCycle(cycle: String): CustomCycle {
+    private fun parseCustomCycle(cycle: String): CustomCycle? {
         val parts = cycle.split("_")
-        val count = parts.getOrNull(1)?.toLongOrNull()?.takeIf { it > 0 } ?: 1L
-        val unit = parts.getOrNull(2)?.takeIf { it in CUSTOM_CYCLE_UNITS } ?: "month"
+        val count = parts.getOrNull(1)?.toLongOrNull()?.takeIf { it > 0 } ?: return null
+        val unit = parts.getOrNull(2)?.takeIf { it in CUSTOM_CYCLE_UNITS } ?: return null
         return CustomCycle(count, unit, parts.getOrNull(3))
     }
 
@@ -28,7 +28,7 @@ object SubscriptionUtils {
         val cycle = billingCycle?.lowercase() ?: "monthly"
 
         if (cycle.startsWith("custom_")) {
-            val (count, unit, _) = parseCustomCycle(cycle)
+            val (count, unit, _) = parseCustomCycle(cycle) ?: return "Monthly"
             return if (count == 1L) "Every $unit" else "Every $count ${unit}s"
         }
 
@@ -45,7 +45,7 @@ object SubscriptionUtils {
         val cycle = billingCycle?.lowercase() ?: "monthly"
 
         if (cycle.startsWith("custom_")) {
-            val (count, unit, _) = parseCustomCycle(cycle)
+            val (count, unit, _) = parseCustomCycle(cycle) ?: return amount
             val divisor = BigDecimal(count)
             return when (unit) {
                 "day"  -> amount.multiply(AVG_DAYS_PER_MONTH).divide(divisor, MC)
@@ -76,8 +76,9 @@ object SubscriptionUtils {
         val today = LocalDate.now()
         val cycle = billingCycle?.lowercase() ?: "monthly"
         
-        if (cycle.startsWith("custom_")) {
-            val (count, unit, endDateStr) = parseCustomCycle(cycle)
+        val custom = if (cycle.startsWith("custom_")) parseCustomCycle(cycle) else null
+        if (custom != null) {
+            val (count, unit, endDateStr) = custom
 
             fun LocalDate.advance(): LocalDate = when (unit) {
                 "day"  -> plusDays(count)

--- a/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
+++ b/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
@@ -1,9 +1,44 @@
 package com.ritesh.cashiro.utils
 
 import android.util.Log
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 
 object SubscriptionUtils {
+
+    private val WEEKS_PER_YEAR = BigDecimal(52)
+    private val MONTHS_PER_YEAR = BigDecimal(12)
+    private val MONTHS_PER_QUARTER = BigDecimal(3)
+    private val MONTHS_PER_HALF = BigDecimal(6)
+    private val AVG_DAYS_PER_MONTH = BigDecimal("30.4375")
+    private val MC = MathContext.DECIMAL64
+
+    fun monthlyEquivalent(amount: BigDecimal, billingCycle: String?): BigDecimal {
+        val cycle = billingCycle?.lowercase() ?: "monthly"
+
+        if (cycle.startsWith("custom_")) {
+            val parts = cycle.split("_")
+            val count = parts.getOrNull(1)?.toLongOrNull()?.takeIf { it > 0 } ?: 1L
+            val unit = parts.getOrNull(2) ?: "month"
+            val divisor = BigDecimal(count)
+            return when (unit) {
+                "day"  -> amount.multiply(AVG_DAYS_PER_MONTH).divide(divisor, MC)
+                "week" -> amount.multiply(WEEKS_PER_YEAR).divide(MONTHS_PER_YEAR.multiply(divisor), MC)
+                "year" -> amount.divide(MONTHS_PER_YEAR.multiply(divisor), MC)
+                else   -> amount.divide(divisor, MC)
+            }
+        }
+
+        return when (cycle) {
+            "weekly"      -> amount.multiply(WEEKS_PER_YEAR).divide(MONTHS_PER_YEAR, MC)
+            "quarterly"   -> amount.divide(MONTHS_PER_QUARTER, MC)
+            "semi-annual" -> amount.divide(MONTHS_PER_HALF, MC)
+            "annual"      -> amount.divide(MONTHS_PER_YEAR, MC)
+            else          -> amount
+        }
+    }
+
     /**
      * Calculates the next payment date based on the current date and billing cycle.
      * Supports standard cycles (Weekly, Monthly, Quarterly, Semi-Annual, Annual)

--- a/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
+++ b/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
@@ -41,6 +41,16 @@ object SubscriptionUtils {
         }
     }
 
+    fun cycleSubtitle(amount: BigDecimal, currency: String, billingCycle: String?): String {
+        val cycleLabel = formatBillingCycle(billingCycle)
+        val monthlyEq = monthlyEquivalent(amount, billingCycle)
+        return if (monthlyEq.compareTo(amount) == 0) {
+            cycleLabel
+        } else {
+            "$cycleLabel · ≈ ${CurrencyFormatter.formatCurrency(monthlyEq, currency)}/mo"
+        }
+    }
+
     fun monthlyEquivalent(amount: BigDecimal, billingCycle: String?): BigDecimal {
         val cycle = billingCycle?.lowercase() ?: "monthly"
 

--- a/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
+++ b/app/src/main/java/com/ritesh/cashiro/utils/SubscriptionUtils.kt
@@ -13,14 +13,39 @@ object SubscriptionUtils {
     private val MONTHS_PER_HALF = BigDecimal(6)
     private val AVG_DAYS_PER_MONTH = BigDecimal("30.4375")
     private val MC = MathContext.DECIMAL64
+    private val CUSTOM_CYCLE_UNITS = setOf("day", "week", "month", "year")
+
+    private data class CustomCycle(val count: Long, val unit: String, val endDate: String?)
+
+    private fun parseCustomCycle(cycle: String): CustomCycle {
+        val parts = cycle.split("_")
+        val count = parts.getOrNull(1)?.toLongOrNull()?.takeIf { it > 0 } ?: 1L
+        val unit = parts.getOrNull(2)?.takeIf { it in CUSTOM_CYCLE_UNITS } ?: "month"
+        return CustomCycle(count, unit, parts.getOrNull(3))
+    }
+
+    fun formatBillingCycle(billingCycle: String?): String {
+        val cycle = billingCycle?.lowercase() ?: "monthly"
+
+        if (cycle.startsWith("custom_")) {
+            val (count, unit, _) = parseCustomCycle(cycle)
+            return if (count == 1L) "Every $unit" else "Every $count ${unit}s"
+        }
+
+        return when (cycle) {
+            "weekly"      -> "Weekly"
+            "quarterly"   -> "Quarterly"
+            "semi-annual" -> "Semi-annual"
+            "annual"      -> "Annual"
+            else          -> "Monthly"
+        }
+    }
 
     fun monthlyEquivalent(amount: BigDecimal, billingCycle: String?): BigDecimal {
         val cycle = billingCycle?.lowercase() ?: "monthly"
 
         if (cycle.startsWith("custom_")) {
-            val parts = cycle.split("_")
-            val count = parts.getOrNull(1)?.toLongOrNull()?.takeIf { it > 0 } ?: 1L
-            val unit = parts.getOrNull(2) ?: "month"
+            val (count, unit, _) = parseCustomCycle(cycle)
             val divisor = BigDecimal(count)
             return when (unit) {
                 "day"  -> amount.multiply(AVG_DAYS_PER_MONTH).divide(divisor, MC)
@@ -52,42 +77,29 @@ object SubscriptionUtils {
         val cycle = billingCycle?.lowercase() ?: "monthly"
         
         if (cycle.startsWith("custom_")) {
-            val parts = cycle.split("_")
-            val count = parts.getOrNull(1)?.toLongOrNull() ?: 1L
-            val unit = parts.getOrNull(2) ?: "month"
-            val endDateStr = parts.getOrNull(3)
-            
-            var nextDate = when (unit) {
-                "day" -> fromDate.plusDays(count)
-                "week" -> fromDate.plusWeeks(count)
-                "year" -> fromDate.plusYears(count)
-                else -> fromDate.plusMonths(count) // month
+            val (count, unit, endDateStr) = parseCustomCycle(cycle)
+
+            fun LocalDate.advance(): LocalDate = when (unit) {
+                "day"  -> plusDays(count)
+                "week" -> plusWeeks(count)
+                "year" -> plusYears(count)
+                else   -> plusMonths(count)
             }
-            
-            // Catch up to today if needed
-            while (nextDate.isBefore(today)) {
-                nextDate = when (unit) {
-                    "day" -> nextDate.plusDays(count)
-                    "week" -> nextDate.plusWeeks(count)
-                    "year" -> nextDate.plusYears(count)
-                    else -> nextDate.plusMonths(count)
-                }
-            }
-            
-            // Check if we passed the end date
+
+            var nextDate = fromDate.advance()
+            while (nextDate.isBefore(today)) nextDate = nextDate.advance()
+
             if (endDateStr != null && endDateStr != "forever") {
                 try {
                     val endDate = LocalDate.parse(endDateStr)
                     if (nextDate.isAfter(endDate)) {
-                        // For now we still return it, letting the system handle expiry later
-                        // or we could return null/special value if it shouldn't repeat anymore.
                         Log.d("SubscriptionUtils", "Next date $nextDate is after end date $endDate")
                     }
                 } catch (e: Exception) {
                     Log.e("SubscriptionUtils", "Error parsing end date: $endDateStr", e)
                 }
             }
-            
+
             return nextDate
         }
 

--- a/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
@@ -1,0 +1,60 @@
+package com.ritesh.cashiro.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubscriptionUtilsFormatBillingCycleTest {
+
+    @Test
+    fun `null cycle is labelled Monthly`() {
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle(null))
+    }
+
+    @Test
+    fun `unknown cycle is labelled Monthly`() {
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("fortnightly-ish"))
+    }
+
+    @Test
+    fun `standard cycles use title case`() {
+        assertEquals("Weekly", SubscriptionUtils.formatBillingCycle("weekly"))
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("monthly"))
+        assertEquals("Quarterly", SubscriptionUtils.formatBillingCycle("quarterly"))
+        assertEquals("Semi-annual", SubscriptionUtils.formatBillingCycle("semi-annual"))
+        assertEquals("Annual", SubscriptionUtils.formatBillingCycle("annual"))
+    }
+
+    @Test
+    fun `cycle string is case-insensitive`() {
+        assertEquals("Annual", SubscriptionUtils.formatBillingCycle("ANNUAL"))
+        assertEquals("Quarterly", SubscriptionUtils.formatBillingCycle("Quarterly"))
+    }
+
+    @Test
+    fun `custom cycle with count of one omits the number`() {
+        assertEquals("Every day", SubscriptionUtils.formatBillingCycle("custom_1_day"))
+        assertEquals("Every week", SubscriptionUtils.formatBillingCycle("custom_1_week"))
+        assertEquals("Every month", SubscriptionUtils.formatBillingCycle("custom_1_month"))
+        assertEquals("Every year", SubscriptionUtils.formatBillingCycle("custom_1_year"))
+    }
+
+    @Test
+    fun `custom cycle with count greater than one pluralises the unit`() {
+        assertEquals("Every 2 weeks", SubscriptionUtils.formatBillingCycle("custom_2_week"))
+        assertEquals("Every 3 months", SubscriptionUtils.formatBillingCycle("custom_3_month"))
+        assertEquals("Every 5 days", SubscriptionUtils.formatBillingCycle("custom_5_day"))
+        assertEquals("Every 2 years", SubscriptionUtils.formatBillingCycle("custom_2_year"))
+    }
+
+    @Test
+    fun `custom cycle ignores end date suffix`() {
+        assertEquals("Every 2 months", SubscriptionUtils.formatBillingCycle("custom_2_month_2026-12-31"))
+        assertEquals("Every month", SubscriptionUtils.formatBillingCycle("custom_1_month_forever"))
+    }
+
+    @Test
+    fun `custom cycle with malformed parts falls back to monthly`() {
+        assertEquals("Every month", SubscriptionUtils.formatBillingCycle("custom_"))
+        assertEquals("Every month", SubscriptionUtils.formatBillingCycle("custom_abc_xyz"))
+    }
+}

--- a/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
@@ -54,7 +54,20 @@ class SubscriptionUtilsFormatBillingCycleTest {
 
     @Test
     fun `custom cycle with malformed parts falls back to monthly`() {
-        assertEquals("Every month", SubscriptionUtils.formatBillingCycle("custom_"))
-        assertEquals("Every month", SubscriptionUtils.formatBillingCycle("custom_abc_xyz"))
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("custom_"))
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("custom_abc_xyz"))
+    }
+
+    @Test
+    fun `custom cycle with valid unit but invalid count falls back to monthly`() {
+        // Coderabbit catch: "custom_abc_day" should not silently become "Every day".
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("custom_abc_day"))
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("custom_-3_week"))
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("custom_0_month"))
+    }
+
+    @Test
+    fun `custom cycle with valid count but invalid unit falls back to monthly`() {
+        assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("custom_2_decade"))
     }
 }

--- a/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
@@ -2,6 +2,7 @@ package com.ritesh.cashiro.utils
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.math.BigDecimal
 
 class SubscriptionUtilsFormatBillingCycleTest {
 
@@ -74,7 +75,7 @@ class SubscriptionUtilsFormatBillingCycleTest {
     @Test
     fun `cycle subtitle for monthly returns just the cycle label`() {
         val subtitle = SubscriptionUtils.cycleSubtitle(
-            amount = java.math.BigDecimal("500"),
+            amount = BigDecimal("500"),
             currency = "INR",
             billingCycle = "monthly"
         )
@@ -84,7 +85,7 @@ class SubscriptionUtilsFormatBillingCycleTest {
     @Test
     fun `cycle subtitle for non-monthly appends the per-month equivalent`() {
         val subtitle = SubscriptionUtils.cycleSubtitle(
-            amount = java.math.BigDecimal("1390"),
+            amount = BigDecimal("1390"),
             currency = "INR",
             billingCycle = "annual"
         )
@@ -95,17 +96,18 @@ class SubscriptionUtilsFormatBillingCycleTest {
     @Test
     fun `cycle subtitle for custom cycle with valid count appends per-month equivalent`() {
         val subtitle = SubscriptionUtils.cycleSubtitle(
-            amount = java.math.BigDecimal("100"),
+            amount = BigDecimal("100"),
             currency = "INR",
             billingCycle = "custom_2_week"
         )
+        // 100 * 52 / 12 / 2 = 216.67
         assertEquals("Every 2 weeks · ≈ ₹216.67/mo", subtitle)
     }
 
     @Test
     fun `cycle subtitle for malformed custom cycle returns just Monthly`() {
         val subtitle = SubscriptionUtils.cycleSubtitle(
-            amount = java.math.BigDecimal("250"),
+            amount = BigDecimal("250"),
             currency = "INR",
             billingCycle = "custom_abc_day"
         )

--- a/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsFormatBillingCycleTest.kt
@@ -70,4 +70,45 @@ class SubscriptionUtilsFormatBillingCycleTest {
     fun `custom cycle with valid count but invalid unit falls back to monthly`() {
         assertEquals("Monthly", SubscriptionUtils.formatBillingCycle("custom_2_decade"))
     }
+
+    @Test
+    fun `cycle subtitle for monthly returns just the cycle label`() {
+        val subtitle = SubscriptionUtils.cycleSubtitle(
+            amount = java.math.BigDecimal("500"),
+            currency = "INR",
+            billingCycle = "monthly"
+        )
+        assertEquals("Monthly", subtitle)
+    }
+
+    @Test
+    fun `cycle subtitle for non-monthly appends the per-month equivalent`() {
+        val subtitle = SubscriptionUtils.cycleSubtitle(
+            amount = java.math.BigDecimal("1390"),
+            currency = "INR",
+            billingCycle = "annual"
+        )
+        // 1390 / 12 = 115.83
+        assertEquals("Annual · ≈ ₹115.83/mo", subtitle)
+    }
+
+    @Test
+    fun `cycle subtitle for custom cycle with valid count appends per-month equivalent`() {
+        val subtitle = SubscriptionUtils.cycleSubtitle(
+            amount = java.math.BigDecimal("100"),
+            currency = "INR",
+            billingCycle = "custom_2_week"
+        )
+        assertEquals("Every 2 weeks · ≈ ₹216.67/mo", subtitle)
+    }
+
+    @Test
+    fun `cycle subtitle for malformed custom cycle returns just Monthly`() {
+        val subtitle = SubscriptionUtils.cycleSubtitle(
+            amount = java.math.BigDecimal("250"),
+            currency = "INR",
+            billingCycle = "custom_abc_day"
+        )
+        assertEquals("Monthly", subtitle)
+    }
 }

--- a/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsMonthlyEquivalentTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsMonthlyEquivalentTest.kt
@@ -81,9 +81,16 @@ class SubscriptionUtilsMonthlyEquivalentTest {
     }
 
     @Test
-    fun `malformed custom cycle defaults count to 1 and unit to month`() {
+    fun `malformed custom cycle falls back to monthly`() {
         assertEqualsMoney(bd("250"), SubscriptionUtils.monthlyEquivalent(bd("250"), "custom_"))
         assertEqualsMoney(bd("250"), SubscriptionUtils.monthlyEquivalent(bd("250"), "custom_abc_xyz"))
+    }
+
+    @Test
+    fun `custom cycle with invalid count but valid unit falls back to monthly`() {
+        // Coderabbit catch: "custom_abc_day" must not become amount * 30.4375 (every day).
+        assertEqualsMoney(bd("250"), SubscriptionUtils.monthlyEquivalent(bd("250"), "custom_abc_day"))
+        assertEqualsMoney(bd("250"), SubscriptionUtils.monthlyEquivalent(bd("250"), "custom_0_month"))
     }
 
     @Test

--- a/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsMonthlyEquivalentTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/utils/SubscriptionUtilsMonthlyEquivalentTest.kt
@@ -1,0 +1,111 @@
+package com.ritesh.cashiro.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+class SubscriptionUtilsMonthlyEquivalentTest {
+
+    private fun bd(value: String) = BigDecimal(value)
+
+    private fun assertEqualsMoney(expected: BigDecimal, actual: BigDecimal, message: String = "") {
+        val e = expected.setScale(2, RoundingMode.HALF_UP)
+        val a = actual.setScale(2, RoundingMode.HALF_UP)
+        assertEquals(message, e, a)
+    }
+
+    @Test
+    fun `monthly cycle returns amount unchanged`() {
+        assertEqualsMoney(bd("5000"), SubscriptionUtils.monthlyEquivalent(bd("5000"), "monthly"))
+    }
+
+    @Test
+    fun `null cycle defaults to monthly`() {
+        assertEqualsMoney(bd("427"), SubscriptionUtils.monthlyEquivalent(bd("427"), null))
+    }
+
+    @Test
+    fun `unknown cycle defaults to monthly`() {
+        assertEqualsMoney(bd("427"), SubscriptionUtils.monthlyEquivalent(bd("427"), "fortnightly-ish"))
+    }
+
+    @Test
+    fun `cycle string is case-insensitive`() {
+        assertEqualsMoney(bd("5000"), SubscriptionUtils.monthlyEquivalent(bd("5000"), "MONTHLY"))
+    }
+
+    @Test
+    fun `weekly cycle annualizes by 52 then divides by 12`() {
+        assertEqualsMoney(bd("433.33"), SubscriptionUtils.monthlyEquivalent(bd("100"), "weekly"))
+    }
+
+    @Test
+    fun `quarterly cycle divides amount by 3`() {
+        assertEqualsMoney(bd("100"), SubscriptionUtils.monthlyEquivalent(bd("300"), "quarterly"))
+    }
+
+    @Test
+    fun `semi-annual cycle divides amount by 6`() {
+        assertEqualsMoney(bd("100"), SubscriptionUtils.monthlyEquivalent(bd("600"), "semi-annual"))
+    }
+
+    @Test
+    fun `annual cycle divides amount by 12`() {
+        assertEqualsMoney(bd("115.83"), SubscriptionUtils.monthlyEquivalent(bd("1390"), "annual"))
+    }
+
+    @Test
+    fun `custom monthly cycle divides by count`() {
+        assertEqualsMoney(bd("100"), SubscriptionUtils.monthlyEquivalent(bd("200"), "custom_2_month"))
+    }
+
+    @Test
+    fun `custom monthly cycle ignores end date suffix`() {
+        assertEqualsMoney(bd("100"), SubscriptionUtils.monthlyEquivalent(bd("200"), "custom_2_month_2026-12-31"))
+    }
+
+    @Test
+    fun `custom day cycle uses average month length`() {
+        assertEqualsMoney(bd("304.38"), SubscriptionUtils.monthlyEquivalent(bd("10"), "custom_1_day"))
+    }
+
+    @Test
+    fun `custom week cycle annualizes then divides`() {
+        assertEqualsMoney(bd("216.67"), SubscriptionUtils.monthlyEquivalent(bd("100"), "custom_2_week"))
+    }
+
+    @Test
+    fun `custom year cycle divides by 12 times count`() {
+        assertEqualsMoney(bd("100"), SubscriptionUtils.monthlyEquivalent(bd("2400"), "custom_2_year"))
+    }
+
+    @Test
+    fun `malformed custom cycle defaults count to 1 and unit to month`() {
+        assertEqualsMoney(bd("250"), SubscriptionUtils.monthlyEquivalent(bd("250"), "custom_"))
+        assertEqualsMoney(bd("250"), SubscriptionUtils.monthlyEquivalent(bd("250"), "custom_abc_xyz"))
+    }
+
+    @Test
+    fun `zero amount stays zero across cycles`() {
+        assertEqualsMoney(BigDecimal.ZERO, SubscriptionUtils.monthlyEquivalent(BigDecimal.ZERO, "annual"))
+        assertEqualsMoney(BigDecimal.ZERO, SubscriptionUtils.monthlyEquivalent(BigDecimal.ZERO, "custom_3_week"))
+    }
+
+    @Test
+    fun `regression for issue 84 mixed monthly and yearly normalizes to expected total`() {
+        val items = listOf(
+            bd("5000")  to "monthly",
+            bd("5000")  to "monthly",
+            bd("427")   to "monthly",
+            bd("1390")  to "annual",
+            bd("299.5") to "annual",
+        )
+
+        val total = items.fold(BigDecimal.ZERO) { acc, (amount, cycle) ->
+            acc.add(SubscriptionUtils.monthlyEquivalent(amount, cycle))
+        }
+
+        assertEqualsMoney(bd("10567.79"), total)
+    }
+}


### PR DESCRIPTION
## Summary

<!-- Briefly explain the change and why it’s needed. Keep it focused. -->

## Type of change

- [ ] feat: New feature
- [X] fix: Bug fix
- [ ] docs: Documentation update
- [x] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [x] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)
<img width="450" height="938" alt="image" src="https://github.com/user-attachments/assets/4d98a218-8cd8-428f-a29d-4d7aef08b9c1" />
<img width="468" height="947" alt="image" src="https://github.com/user-attachments/assets/60af07c8-ed75-456e-a8f1-981d3bf81c36" />

<!-- Add images or videos for UI changes. -->

## How to test

<!-- Steps for reviewers to verify the change locally. -->
1. Add some Subscription with various billing cycle
2. Check the total subscription Calucation is Valid based on it

## Breaking changes

- [X] No breaking changes
- [ ] Yes (describe): 

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

- Added a cycle chip on each subscription row (Monthly, Weekly, Annual, Every N months, etc.)
- Added a per-month equivalent line under the amount in the Track Payment bottom sheet (e.g. Annual ~ Rs.2,083.33/mo)
- Custom cycles render with proper singular/plural (Every day, Every 2 weeks)
- Hardened parseCustomCycle so malformed input (custom_abc_day, custom_0_month, custom_2_decade) falls back to monthly instead of silently becoming a valid schedule
- Fixed a latent infinite-loop bug in calculateNextPaymentDate when a custom cycle had count=0 (now defaults to 1)
- FX conversion failures no longer poison totals (the failed sub is excluded from the sum instead of being added in the source currency)
- New "N subscription(s) couldn't be converted to X, totals may be incomplete" warning under the totals card when at least one FX conversion fails
- Refactored the shared custom_<n>_<unit>_<end> parsing into a single private parseCustomCycle helper used by formatBillingCycle, monthlyEquivalent, and calculateNextPaymentDate
- Hoisted BigDecimal time constants (52, 12, 6, 3, 30.4375) and the custom-unit set to private vals to avoid per-call allocations
- Yearly total is now derived from the normalized monthly value (yearly = monthly x 12), so both totals cards stay consistent
- Added 28 unit tests covering all standard cycles, custom cycles (singular/plural, end-date suffix, malformed input), zero amounts, case-insensitivity, and a regression pin reproducing the exact scenario from issue #84

## Checklist

- [ ] Focused PR (single purpose)
- [X] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [] `./gradlew test` passes locally (Pre-existing errors are there , this pr implementation test are passed)
- [] `./gradlew lint` passes locally (Pre-existing errors are there , this pr implementation lint are valid)
- [X] Follows existing code style and patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing cycle labels added to subscription items and payment details, showing per-month equivalents when applicable.
  * Converted amounts and target currency shown in payment details and used for displayed totals.
  * Totals now show a conversion-failure warning when conversions fail.

* **Tests**
  * New tests covering billing-cycle labeling and monthly-equivalent conversions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-kanwar/Cashiro/pull/90)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->