### PR TITLE
Exhaustive backport of Pennywise SMS reader overhaul + parser fixes to Cashiro

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,6 +127,15 @@ android {
         }
     }
 
+    packaging {
+        resources {
+            excludes += setOf(
+                "META-INF/LICENSE.md",
+                "META-INF/LICENSE-notice.md",
+                "META-INF/NOTICE.md",
+            )
+        }
+    }
     buildFeatures {
         compose = true
     }

--- a/app/schemas/com.ritesh.cashiro.data.database.CashiroDatabase/52.json
+++ b/app/schemas/com.ritesh.cashiro.data.database.CashiroDatabase/52.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 52,
-    "identityHash": "7af7c786b43a1ea50bbb1592e2df5bfb",
+    "identityHash": "042e41f1724f251d405ab9be9978193f",
     "entities": [
       {
         "tableName": "transactions",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `subcategory` TEXT, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `billing_cycle` TEXT, `attachments` TEXT NOT NULL DEFAULT '', `is_sample` INTEGER NOT NULL DEFAULT 0)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `subcategory` TEXT, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `billing_cycle` TEXT, `attachments` TEXT NOT NULL DEFAULT '', `is_sample` INTEGER NOT NULL DEFAULT 0)",
         "fields": [
           {
             "fieldPath": "id",
@@ -126,6 +126,11 @@
           {
             "fieldPath": "toAccount",
             "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
             "affinity": "TEXT"
           },
           {
@@ -313,7 +318,7 @@
       },
       {
         "tableName": "merchant_mappings",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `subcategory` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
         "fields": [
           {
             "fieldPath": "merchantName",
@@ -326,11 +331,6 @@
             "columnName": "category",
             "affinity": "TEXT",
             "notNull": true
-          },
-          {
-            "fieldPath": "subcategory",
-            "columnName": "subcategory",
-            "affinity": "TEXT"
           },
           {
             "fieldPath": "createdAt",
@@ -1691,7 +1691,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7af7c786b43a1ea50bbb1592e2df5bfb')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '042e41f1724f251d405ab9be9978193f')"
     ]
   }
 }

--- a/app/src/main/java/com/ritesh/cashiro/data/database/CashiroDatabase.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/CashiroDatabase.kt
@@ -75,7 +75,7 @@ import com.ritesh.cashiro.data.database.entity.WebhookProfileEntity
             WebhookLogEntity::class,
             WebhookCursorEntity::class
         ],
-    version = 51,
+    version = 52,
     exportSchema = true,
     autoMigrations =
         [
@@ -149,7 +149,8 @@ abstract class CashiroDatabase : RoomDatabase() {
                                 MIGRATION_29_30,
                                 MIGRATION_48_49,
                                 MIGRATION_49_50,
-                                MIGRATION_50_51
+                                MIGRATION_50_51,
+                                MIGRATION_51_52
                             )
                             .build()
                     INSTANCE = instance
@@ -1424,9 +1425,22 @@ class Migration46To47 : AutoMigrationSpec {
             "Refund" to "type_finance_currency_exchange",
             "Other" to "type_stationary_clipboard"
         )
-        
+
         subcategoryMappings.forEach { (name, iconName) ->
             db.execSQL("UPDATE subcategories SET icon_name = ?, default_icon_name = ? WHERE name = ? AND is_system = 1", arrayOf(iconName, iconName, name))
         }
     }
 }
+
+/**
+ * Manual migration 51 -> 52.
+ *
+ * Adds the `reference` column to the transactions table for UPI transaction
+ * deduplication support.
+ */
+val MIGRATION_51_52 =
+    object : Migration(51, 52) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE transactions ADD COLUMN reference TEXT")
+        }
+    }

--- a/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
@@ -154,6 +154,9 @@ interface AccountBalanceDao {
     @Query("DELETE FROM account_balances WHERE id = :id")
     suspend fun deleteBalanceById(id: Long)
     
+    @Query("DELETE FROM account_balances WHERE transaction_id = :transactionId")
+    suspend fun deleteBalancesForTransaction(transactionId: Long): Int
+    
     @Query("UPDATE account_balances SET balance = :newBalance WHERE id = :id")
     suspend fun updateBalanceById(id: Long, newBalance: BigDecimal)
     

--- a/app/src/main/java/com/ritesh/cashiro/data/database/dao/MerchantMappingDao.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/dao/MerchantMappingDao.kt
@@ -19,6 +19,9 @@ interface MerchantMappingDao {
     @Query("DELETE FROM merchant_mappings WHERE merchant_name = :merchantName")
     suspend fun deleteMapping(merchantName: String)
     
+    @Query("SELECT * FROM merchant_mappings")
+    suspend fun getAllMappingsList(): List<MerchantMappingEntity>
+
     @Query("SELECT * FROM merchant_mappings ORDER BY merchant_name ASC")
     fun getAllMappings(): Flow<List<MerchantMappingEntity>>
     

--- a/app/src/main/java/com/ritesh/cashiro/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/dao/TransactionDao.kt
@@ -3,6 +3,7 @@ package com.ritesh.cashiro.data.database.dao
 import androidx.room.*
 import com.ritesh.cashiro.data.database.entity.TransactionEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
 
@@ -153,6 +154,35 @@ interface TransactionDao {
     
     @Query("DELETE FROM transactions WHERE is_sample = 1")
     suspend fun deleteSampleTransactions()
+
+    @Query("""
+        SELECT * FROM transactions
+        WHERE is_deleted = 0
+        AND reference = :reference
+        AND amount = :amount
+        AND transaction_type = :transactionType
+        AND currency = :currency
+        AND date_time BETWEEN :startDate AND :endDate
+        AND (:accountNumber IS NULL OR account_number = :accountNumber OR account_number IS NULL)
+        ORDER BY date_time ASC
+    """)
+    suspend fun findPotentialDuplicatesByReference(
+        reference: String,
+        amount: BigDecimal,
+        transactionType: TransactionType,
+        currency: String,
+        accountNumber: String?,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<TransactionEntity>
+
+    @Query("""
+        SELECT * FROM transactions
+        WHERE is_deleted = 0
+        AND reference GLOB '[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+        ORDER BY reference ASC, date_time ASC
+    """)
+    suspend fun findPotentialDuplicatesByReference(): List<TransactionEntity>
 
     @Query("UPDATE transactions SET category = :newCategory WHERE merchant_name = :merchantName")
     suspend fun updateCategoryForMerchant(merchantName: String, newCategory: String)

--- a/app/src/main/java/com/ritesh/cashiro/data/database/entity/TransactionEntity.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/entity/TransactionEntity.kt
@@ -30,6 +30,7 @@ data class TransactionEntity(
         @ColumnInfo(name = "currency", defaultValue = "INR") val currency: String = "INR",
         @ColumnInfo(name = "from_account") val fromAccount: String? = null,
         @ColumnInfo(name = "to_account") val toAccount: String? = null,
+        @ColumnInfo(name = "reference") val reference: String? = null,
         @ColumnInfo(name = "billing_cycle") val billingCycle: String? = null,
         @ColumnInfo(name = "attachments", defaultValue = "") val attachments: String = "",
         @ColumnInfo(name = "is_sample", defaultValue = "0") val isSample: Boolean = false

--- a/app/src/main/java/com/ritesh/cashiro/data/manager/TransactionDeduplication.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/manager/TransactionDeduplication.kt
@@ -1,0 +1,104 @@
+package com.ritesh.cashiro.data.manager
+
+import com.ritesh.cashiro.data.database.entity.TransactionEntity
+import java.time.Duration
+
+object TransactionDeduplication {
+    private val upiReferencePattern = Regex("""\d{12}""")
+    val UPI_DUPLICATE_WINDOW: Duration = Duration.ofMinutes(3)
+
+    fun hasUpiReference(transaction: TransactionEntity): Boolean =
+        transaction.reference?.let { upiReferencePattern.matches(it) } == true
+
+    fun isSameUpiTransaction(
+        existing: TransactionEntity,
+        incoming: TransactionEntity,
+        window: Duration = UPI_DUPLICATE_WINDOW
+    ): Boolean {
+        if (!hasUpiReference(existing) || !hasUpiReference(incoming)) return false
+        if (existing.reference != incoming.reference) return false
+        if (existing.transactionType != incoming.transactionType) return false
+        if (existing.currency != incoming.currency) return false
+        if (existing.amount.compareTo(incoming.amount) != 0) return false
+        if (!accountsMatch(existing.accountNumber, incoming.accountNumber)) return false
+
+        val gap = Duration.between(existing.dateTime, incoming.dateTime).abs()
+        return gap <= window
+    }
+
+    fun shouldReplaceWithIncoming(
+        existing: TransactionEntity,
+        incoming: TransactionEntity
+    ): Boolean {
+        if (!isSameUpiTransaction(existing, incoming)) return false
+
+        val existingIsPartnerBank = existing.bankName.equals("State Bank of India", ignoreCase = true)
+        val incomingIsPartnerBank = incoming.bankName.equals("State Bank of India", ignoreCase = true)
+        if (existingIsPartnerBank && !incomingIsPartnerBank) return true
+        if (!existingIsPartnerBank && incomingIsPartnerBank) return false
+
+        return existing.balanceAfter == null && incoming.balanceAfter != null
+    }
+
+    fun duplicateIdsToDelete(transactions: List<TransactionEntity>): List<Long> {
+        return transactions
+            .filter { !it.isDeleted && hasUpiReference(it) }
+            .groupBy {
+                DuplicateKey(
+                    reference = it.reference.orEmpty(),
+                    amount = it.amount.stripTrailingZeros().toPlainString(),
+                    accountNumber = it.accountNumber.orEmpty(),
+                    transactionType = it.transactionType.name,
+                    currency = it.currency
+                )
+            }
+            .values
+            .flatMap { group -> duplicateIdsFromGroup(group) }
+    }
+
+    private fun duplicateIdsFromGroup(group: List<TransactionEntity>): List<Long> {
+        val duplicateClusters = mutableListOf<MutableList<TransactionEntity>>()
+
+        group.sortedWith(compareBy<TransactionEntity> { it.dateTime }.thenBy { it.id })
+            .forEach { transaction ->
+                val matchingCluster = duplicateClusters.firstOrNull { cluster ->
+                    cluster.any { previous -> isSameUpiTransaction(previous, transaction) }
+                }
+
+                if (matchingCluster == null) {
+                    duplicateClusters += mutableListOf(transaction)
+                } else {
+                    matchingCluster += transaction
+                }
+            }
+
+        return duplicateClusters.flatMap { cluster ->
+            val keeper = cluster.minWith(transactionQualityComparator)
+            cluster
+                .filter { it.id != keeper.id }
+                .sortedWith(compareBy<TransactionEntity> { it.dateTime }.thenBy { it.id })
+                .map { it.id }
+        }
+    }
+
+    private val transactionQualityComparator = compareBy<TransactionEntity>(
+        { it.bankName.equals("State Bank of India", ignoreCase = true) },
+        { it.balanceAfter == null },
+        { it.dateTime },
+        { it.id }
+    )
+
+    private fun accountsMatch(existingAccount: String?, incomingAccount: String?): Boolean {
+        return existingAccount.isNullOrBlank() ||
+                incomingAccount.isNullOrBlank() ||
+                existingAccount == incomingAccount
+    }
+
+    private data class DuplicateKey(
+        val reference: String,
+        val amount: String,
+        val accountNumber: String,
+        val transactionType: String,
+        val currency: String
+    )
+}

--- a/app/src/main/java/com/ritesh/cashiro/data/mapper/ParsedTransactionMapper.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/mapper/ParsedTransactionMapper.kt
@@ -48,7 +48,8 @@ fun ParsedTransaction.toEntity(): TransactionEntity {
         updatedAt = dateTime,
         currency = currency,
         fromAccount = fromAccount,
-        toAccount = toAccount
+        toAccount = toAccount,
+        reference = reference
     )
 }
 

--- a/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
@@ -4,9 +4,9 @@ import android.util.Log
 import com.ritesh.parser.core.ParsedTransaction
 import com.ritesh.parser.core.TransactionType
 import java.math.BigDecimal
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 interface PdfStatementParser {
     fun canHandle(text: String): Boolean
@@ -14,137 +14,185 @@ interface PdfStatementParser {
 }
 
 class GPayPdfParser : PdfStatementParser {
+
+    companion object {
+        private const val TAG = "GPayPdfParser"
+        private const val DATE_FORMAT_PATTERN = "dd MMM, yyyy hh:mm a"
+        private const val DATE_BUFFER_SIZE = 8
+    }
+
+    private val IST = TimeZone.getTimeZone("Asia/Kolkata")
+
+    private val merchantAnchorRegex = Regex("""^Paid\s+to\s+(.+)$""", RegexOption.IGNORE_CASE)
+    private val receivedAnchorRegex = Regex("""^Received\s+from\s+(.+)$""", RegexOption.IGNORE_CASE)
+    private val bankAccountLineRegex = Regex("""^Paid\s+(?:by|to)\s+(.+)\s+(Bank|Card|A/c)\s+(\d{4})$""", RegexOption.IGNORE_CASE)
+    private val upiIdRegex = Regex("""UPI\s+Transaction\s+ID[:\s]+(\d+)""", RegexOption.IGNORE_CASE)
+    private val amountRegex = Regex("""^(?:₹|Rs\.?)\s*([0-9][0-9,]*(?:\.[0-9]{1,2})?)$""")
+    private val dateLineRegex = Regex("""^(\d{1,2})\s+(\w{3}),?$""")
+    private val yearLineRegex = Regex("""^(20\d{2})$""")
+    private val timeLineRegex = Regex("""^(\d{1,2}:\d{2})\s*([AaPp][Mm])$""")
+
     override fun canHandle(text: String): Boolean {
-        val canHandle = (text.contains("GPay", ignoreCase = true) || text.contains("Google Pay", ignoreCase = true)) 
-                        && text.contains("UPI Transaction ID", ignoreCase = true)
-        Log.d("PDF_PARSER_DEBUG", "GPayPdfParser canHandle: $canHandle")
-        return canHandle
+        val lower = text.lowercase()
+        val result = ("google pay" in lower || "gpay" in lower) && "upi transaction id" in lower
+        Log.d(TAG, "canHandle=$result")
+        return result
     }
 
     override fun parse(text: String): List<ParsedTransaction> {
-        Log.d("PDF_PARSER_DEBUG", "GPayPdfParser starting parse. Text size: ${text.length}")
-        val transactions = mutableListOf<ParsedTransaction>()
-
-        // Regex to find start of a transaction (Date pattern)
-        // More flexible date: "01 Aug 2025" or "01 Aug, 2025"
-        // Also handling possible newlines between date and time
-        val dateRegex = Regex(
-            """(\d{1,2}\s+[A-Za-z]{3},?\s+\d{4})\s*(\d{1,2}:\d{2}\s+[AP]M)""",
-            RegexOption.IGNORE_CASE
-        )
-
-        val matches = dateRegex.findAll(text).toList()
-        if (matches.isEmpty()) return emptyList()
-
-        val allRows = mutableListOf<String>()
-        for (i in matches.indices) {
-            val start = matches[i].range.first
-            val end = if (i + 1 < matches.size) matches[i + 1].range.first else text.length
-            allRows.add(text.substring(start, end).replace(Regex("""\s+"""), " "))
-        }
-
-        val amountRegex = Regex("""(?:₹|Rs\.?)\s*([0-9,]+(?:\.\d+)?)""", RegexOption.IGNORE_CASE)
-
-        for (row in allRows) {
-            val dateMatch = dateRegex.find(row) ?: continue
-            val dateStr = dateMatch.groupValues[1]
-            val timeStr = dateMatch.groupValues[2]
-
-            val dateTime = try {
-                val cleanedDate = dateStr.replace(",", "")
-                LocalDateTime.parse(
-                    "$cleanedDate $timeStr",
-                    DateTimeFormatter.ofPattern("d MMM yyyy h:mm a", Locale.ENGLISH)
-                )
-            } catch (e: Exception) {
-                try {
-                    val cleanedDate = dateStr.replace(",", "")
-                    LocalDateTime.parse(
-                        "$cleanedDate $timeStr",
-                        DateTimeFormatter.ofPattern("dd MMM yyyy hh:mm a", Locale.ENGLISH)
-                    )
-                } catch (e2: Exception) {
-                    continue
-                }
-            }
-
-            val amountMatch = amountRegex.find(row)
-            val amountStr = amountMatch?.groupValues?.get(1)?.replace(",", "") ?: continue
-            val amount = BigDecimal(amountStr)
-
-            val isIncome = row.contains("Received from", ignoreCase = true)
-            val type = if (isIncome) TransactionType.INCOME else TransactionType.EXPENSE
-
-            // Non-greedy merchant extraction
-            val merchantMatch = if (isIncome) {
-                Regex(
-                    """(?:Received from|Paid by)\s+(.+?)(?=\s+UPI Transaction ID|Paid to|Paid by|$)""",
-                    RegexOption.IGNORE_CASE
-                ).find(row)
-            } else {
-                Regex(
-                    """Paid to\s+(.+?)(?=\s+UPI Transaction ID|Paid to|Paid by|$)""",
-                    RegexOption.IGNORE_CASE
-                ).find(row)
-            }
-
-            val merchant = merchantMatch?.groupValues?.get(1)?.trim() ?: "Unknown"
-
-            // Bank info is usually at the end before the amount
-            // For Expense: "Paid by [Bank] [Last4] [Amount]"
-            // For Income: "Paid to [Bank] [Last4] [Amount]"
-            val bankMatch = if (isIncome) {
-                Regex(
-                    """Paid to\s+(.+?)\s+(\d{4})(?=\s*[₹Rs])""",
-                    RegexOption.IGNORE_CASE
-                ).find(row)
-            } else {
-                Regex(
-                    """Paid by\s+(.+?)\s+(\d{4})(?=\s*[₹Rs])""",
-                    RegexOption.IGNORE_CASE
-                ).find(row)
-            }
-            val bankName = bankMatch?.groupValues?.get(1)?.trim()
-            val accountLast4 = bankMatch?.groupValues?.get(2)
-
-            val upiMatch = Regex("""UPI Transaction ID:\s*(\d+)""").find(row)
-            val upiId = upiMatch?.groupValues?.get(1)
-
-            val originalMessage = buildString {
-                if (isIncome) {
-                    append("Received from $merchant\n")
-                } else {
-                    append("Paid to $merchant\n")
-                }
-                if (upiId != null) append("UPI Transaction ID: $upiId\n")
-                if (bankName != null && accountLast4 != null) {
-                    if (isIncome) {
-                        append("Paid to $bankName $accountLast4")
-                    } else {
-                        append("Paid by $bankName $accountLast4")
-                    }
-                }
-            }.trim()
-
-            transactions.add(
-                ParsedTransaction(
-                    amount = amount,
-                    type = type,
-                    merchant = merchant,
-                    reference = upiId,
-                    accountLast4 = accountLast4,
-                    bankName = bankName ?: "GPay",
-                    smsBody = originalMessage,
-                    timestamp = dateTime.atZone(java.time.ZoneId.systemDefault()).toInstant()
-                        .toEpochMilli(),
-                    sender = "GPay PDF",
-                    balance = null
-                )
-            )
-        }
-
+        Log.i(TAG, "Starting parse — text length=${text.length}")
+        val blocks = splitIntoBlocks(text)
+        Log.i(TAG, "Split into ${blocks.size} blocks")
+        val transactions = blocks.mapIndexedNotNull { index, block -> parseBlock(block, index) }
+        Log.i(TAG, "Finished: ${transactions.size}/${blocks.size} transactions parsed")
         return transactions
     }
+
+    private fun splitIntoBlocks(text: String): List<String> {
+        val blocks = mutableListOf<String>()
+        val buffer = ArrayDeque<String>()
+        val current = StringBuilder()
+        var inBlock = false
+
+        for (rawLine in text.lines()) {
+            val line = rawLine.trim()
+            if (line.isEmpty()) continue
+
+            if (isTransactionAnchor(line)) {
+                if (inBlock && current.isNotEmpty()) {
+                    blocks.add(current.toString().trim())
+                    current.clear()
+                }
+                buffer.forEach { current.appendLine(it) }
+                buffer.clear()
+                inBlock = true
+            }
+
+            if (inBlock) {
+                current.appendLine(line)
+            } else {
+                buffer.addLast(line)
+                if (buffer.size > DATE_BUFFER_SIZE) buffer.removeFirst()
+            }
+        }
+
+        if (current.isNotEmpty()) blocks.add(current.toString().trim())
+        return blocks
+    }
+
+    private fun isTransactionAnchor(line: String): Boolean {
+        if (receivedAnchorRegex.matches(line)) return true
+        if (merchantAnchorRegex.matches(line)) {
+            return !bankAccountLineRegex.matches(line)
+        }
+        return false
+    }
+
+    private fun parseBlock(block: String, index: Int): ParsedTransaction? {
+        val lines = block.lines().map { it.trim() }.filter { it.isNotEmpty() }
+        val anchorLine = lines.firstOrNull { isTransactionAnchor(it) }
+        if (anchorLine == null) {
+            Log.w(TAG, "Block[$index] — no anchor found, skipping")
+            return null
+        }
+
+        val isExpense = merchantAnchorRegex.matches(anchorLine)
+        val type = if (isExpense) TransactionType.EXPENSE else TransactionType.INCOME
+        val merchant = extractMerchant(anchorLine, isExpense)
+        if (merchant == null) {
+            Log.w(TAG, "Block[$index] — could not extract merchant from: '$anchorLine'")
+            return null
+        }
+
+        val amount = extractAmount(lines)
+        if (amount == null) {
+            Log.w(TAG, "Block[$index] merchant='$merchant' — no amount found")
+            return null
+        }
+
+        val timestamp = extractTimestamp(lines, merchant)
+        val upiId = lines.firstNotNullOfOrNull { upiIdRegex.find(it)?.groupValues?.get(1) }
+        val account = extractAccountInfo(lines)
+
+        return ParsedTransaction(
+            amount = amount,
+            type = type,
+            merchant = merchant,
+            reference = upiId,
+            accountLast4 = account.last4,
+            balance = null,
+            smsBody = block,
+            sender = "GPay PDF",
+            timestamp = timestamp ?: System.currentTimeMillis(),
+            bankName = account.bankName ?: "Google Pay"
+        )
+    }
+
+    private fun extractMerchant(anchorLine: String, isExpense: Boolean): String? {
+        val regex = if (isExpense) merchantAnchorRegex else receivedAnchorRegex
+        return regex.find(anchorLine)?.groupValues?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun extractAmount(lines: List<String>): BigDecimal? {
+        for (line in lines) {
+            val raw = amountRegex.find(line)?.groupValues?.get(1) ?: continue
+            val cleaned = raw.replace(",", "")
+            val amount = cleaned.toBigDecimalOrNull()
+            if (amount != null) return amount
+        }
+        return null
+    }
+
+    private fun extractTimestamp(lines: List<String>, merchant: String): Long? {
+        var dateLine: String? = null
+        var yearLine: String? = null
+        var timeLine: String? = null
+
+        for (line in lines) {
+            when {
+                dateLine == null && dateLineRegex.matches(line) -> dateLine = line
+                yearLine == null && yearLineRegex.matches(line) -> yearLine = line
+                timeLine == null && timeLineRegex.matches(line) -> timeLine = line
+            }
+            if (dateLine != null && yearLine != null && timeLine != null) break
+        }
+
+        if (dateLine == null || yearLine == null || timeLine == null) {
+            Log.e(TAG, "Incomplete timestamp for '$merchant'")
+            return null
+        }
+
+        val dateClean = dateLine.trimEnd(',', ' ')
+        val timeClean = timeLine.replace(Regex("""\s+"""), " ").uppercase()
+        val combined = "$dateClean, $yearLine $timeClean"
+
+        return try {
+            val sdf = SimpleDateFormat(DATE_FORMAT_PATTERN, Locale.ENGLISH).apply {
+                timeZone = IST
+                isLenient = false
+            }
+            sdf.parse(combined)?.time
+        } catch (e: Exception) {
+            Log.e(TAG, "Date parse exception for '$merchant' — input='$combined': ${e.message}")
+            null
+        }
+    }
+
+    private fun extractAccountInfo(lines: List<String>): AccountInfo {
+        val accountLine = lines.firstOrNull { bankAccountLineRegex.matches(it) }
+        if (accountLine == null) return AccountInfo(null, null)
+
+        val match = bankAccountLineRegex.find(accountLine)
+        val bankName = if (match != null) {
+            val first = match.groupValues.getOrNull(1)?.trim()
+            val second = match.groupValues.getOrNull(2)?.trim()
+            listOfNotNull(first, second).joinToString(" ").takeIf { it.isNotBlank() }
+        } else null
+        val last4 = match?.groupValues?.getOrNull(3)?.trim()
+        return AccountInfo(bankName, last4)
+    }
+
+    private data class AccountInfo(val bankName: String?, val last4: String?)
 }
 
 

--- a/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
@@ -18,7 +18,6 @@ class GPayPdfParser : PdfStatementParser {
     companion object {
         private const val TAG = "GPayPdfParser"
         private const val DATE_FORMAT_PATTERN = "dd MMM, yyyy hh:mm a"
-        private const val DATE_BUFFER_SIZE = 8
     }
 
     private val IST = TimeZone.getTimeZone("Asia/Kolkata")
@@ -50,33 +49,46 @@ class GPayPdfParser : PdfStatementParser {
 
     private fun splitIntoBlocks(text: String): List<String> {
         val blocks = mutableListOf<String>()
-        val buffer = ArrayDeque<String>()
         val current = StringBuilder()
+        var pendingDate: String? = null
+        var pendingYear: String? = null
+        var pendingTime: String? = null
         var inBlock = false
 
         for (rawLine in text.lines()) {
             val line = rawLine.trim()
             if (line.isEmpty()) continue
 
+            val isDate = dateLineRegex.matches(line)
+            val isYear = yearLineRegex.matches(line)
+            val isTime = timeLineRegex.matches(line)
+
             if (isTransactionAnchor(line)) {
                 if (inBlock && current.isNotEmpty()) {
                     blocks.add(current.toString().trim())
                     current.clear()
                 }
-                buffer.forEach { current.appendLine(it) }
-                buffer.clear()
+                pendingDate?.let { current.appendLine(it) }
+                pendingYear?.let { current.appendLine(it) }
+                pendingTime?.let { current.appendLine(it) }
+                pendingDate = null
+                pendingYear = null
+                pendingTime = null
+                current.appendLine(line)
                 inBlock = true
+                continue
             }
 
-            if (inBlock) {
-                current.appendLine(line)
-            } else {
-                buffer.addLast(line)
-                if (buffer.size > DATE_BUFFER_SIZE) buffer.removeFirst()
-            }
+            if (isDate) { pendingDate = line; continue }
+            if (isYear) { pendingYear = line; continue }
+            if (isTime) { pendingTime = line; continue }
+
+            if (inBlock) current.appendLine(line)
         }
 
         if (current.isNotEmpty()) blocks.add(current.toString().trim())
+
+        Log.d(TAG, "splitIntoBlocks: ${blocks.size} blocks found")
         return blocks
     }
 
@@ -90,9 +102,11 @@ class GPayPdfParser : PdfStatementParser {
 
     private fun parseBlock(block: String, index: Int): ParsedTransaction? {
         val lines = block.lines().map { it.trim() }.filter { it.isNotEmpty() }
+        Log.v(TAG, "Block[$index] lines: $lines")
+
         val anchorLine = lines.firstOrNull { isTransactionAnchor(it) }
         if (anchorLine == null) {
-            Log.w(TAG, "Block[$index] — no anchor found, skipping")
+            Log.w(TAG, "Block[$index] — no anchor found, skipping. Preview: ${lines.take(3)}")
             return null
         }
 
@@ -106,13 +120,15 @@ class GPayPdfParser : PdfStatementParser {
 
         val amount = extractAmount(lines)
         if (amount == null) {
-            Log.w(TAG, "Block[$index] merchant='$merchant' — no amount found")
+            Log.w(TAG, "Block[$index] merchant='$merchant' — no amount found. Lines: $lines")
             return null
         }
 
         val timestamp = extractTimestamp(lines, merchant)
         val upiId = lines.firstNotNullOfOrNull { upiIdRegex.find(it)?.groupValues?.get(1) }
         val account = extractAccountInfo(lines)
+
+        Log.i(TAG, "Block[$index] OK — $type merchant='$merchant' amount=$amount upi=$upiId bank='${account.bankName}' last4=${account.last4}")
 
         return ParsedTransaction(
             amount = amount,
@@ -158,7 +174,7 @@ class GPayPdfParser : PdfStatementParser {
         }
 
         if (dateLine == null || yearLine == null || timeLine == null) {
-            Log.e(TAG, "Incomplete timestamp for '$merchant'")
+            Log.e(TAG, "Incomplete timestamp for '$merchant' — date='$dateLine' year='$yearLine' time='$timeLine'")
             return null
         }
 
@@ -171,7 +187,14 @@ class GPayPdfParser : PdfStatementParser {
                 timeZone = IST
                 isLenient = false
             }
-            sdf.parse(combined)?.time
+            val parsed = sdf.parse(combined)
+            if (parsed == null) {
+                Log.e(TAG, "Date parsed to null for '$merchant' — input='$combined'")
+                null
+            } else {
+                Log.d(TAG, "Timestamp OK for '$merchant' — '$combined' → ${parsed.time}")
+                parsed.time
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Date parse exception for '$merchant' — input='$combined': ${e.message}")
             null
@@ -180,7 +203,10 @@ class GPayPdfParser : PdfStatementParser {
 
     private fun extractAccountInfo(lines: List<String>): AccountInfo {
         val accountLine = lines.firstOrNull { bankAccountLineRegex.matches(it) }
-        if (accountLine == null) return AccountInfo(null, null)
+        if (accountLine == null) {
+            Log.d(TAG, "No account line found in lines: $lines")
+            return AccountInfo(null, null)
+        }
 
         val match = bankAccountLineRegex.find(accountLine)
         val bankName = if (match != null) {
@@ -189,6 +215,8 @@ class GPayPdfParser : PdfStatementParser {
             listOfNotNull(first, second).joinToString(" ").takeIf { it.isNotBlank() }
         } else null
         val last4 = match?.groupValues?.getOrNull(3)?.trim()
+
+        Log.d(TAG, "Account — bank='$bankName' last4='$last4' from '$accountLine'")
         return AccountInfo(bankName, last4)
     }
 

--- a/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
@@ -135,7 +135,11 @@ class AccountBalanceRepository @Inject constructor(
     suspend fun deleteBalanceById(id: Long) {
         accountBalanceDao.deleteBalanceById(id)
     }
-    
+
+    suspend fun deleteBalancesForTransaction(transactionId: Long): Int {
+        return accountBalanceDao.deleteBalancesForTransaction(transactionId)
+    }
+
     suspend fun updateBalanceById(id: Long, newBalance: BigDecimal) {
         accountBalanceDao.updateBalanceById(id, newBalance)
     }

--- a/app/src/main/java/com/ritesh/cashiro/data/repository/MerchantMappingRepository.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/repository/MerchantMappingRepository.kt
@@ -34,6 +34,11 @@ class MerchantMappingRepository @Inject constructor(
         return merchantMappingDao.getAllMappings()
     }
     
+    suspend fun getAllMappingsAsMap(): Map<String, String> {
+        val allMappings = merchantMappingDao.getAllMappingsList()
+        return allMappings.associate { it.merchantName to it.category }
+    }
+
     suspend fun getMappingCount(): Int {
         return merchantMappingDao.getMappingCount()
     }

--- a/app/src/main/java/com/ritesh/cashiro/data/repository/RuleRepositoryImpl.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/repository/RuleRepositoryImpl.kt
@@ -151,6 +151,10 @@ class RuleRepositoryImpl @Inject constructor(
         return ruleApplicationDao.getApplicationCountForRule(ruleId)
     }
 
+    override suspend fun deleteRuleApplicationsForTransaction(transactionId: String) {
+        ruleApplicationDao.deleteApplicationsByTransaction(transactionId)
+    }
+
     private fun ruleToEntity(rule: TransactionRule): RuleEntity {
         return RuleEntity(
             id = rule.id,

--- a/app/src/main/java/com/ritesh/cashiro/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/repository/TransactionRepository.kt
@@ -3,6 +3,7 @@ package com.ritesh.cashiro.data.repository
 import com.ritesh.cashiro.data.database.dao.TransactionDao
 import com.ritesh.cashiro.data.database.entity.TransactionEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
+import com.ritesh.cashiro.data.manager.TransactionDeduplication
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -389,5 +390,27 @@ class TransactionRepository @Inject constructor(private val transactionDao: Tran
     ): List<TransactionEntity> {
         return transactionDao.findPotentialDuplicates(startDate, endDate)
             .filter { it.amount.compareTo(amount) == 0 }
+    }
+
+    suspend fun findPotentialDuplicates(transaction: TransactionEntity): List<TransactionEntity> {
+        if (!TransactionDeduplication.hasUpiReference(transaction)) return emptyList()
+
+        return transactionDao.findPotentialDuplicatesByReference(
+            reference = transaction.reference.orEmpty(),
+            amount = transaction.amount,
+            transactionType = transaction.transactionType,
+            currency = transaction.currency,
+            accountNumber = transaction.accountNumber,
+            startDate = transaction.dateTime.minus(TransactionDeduplication.UPI_DUPLICATE_WINDOW),
+            endDate = transaction.dateTime.plus(TransactionDeduplication.UPI_DUPLICATE_WINDOW)
+        ).filter { candidate ->
+            candidate.id != transaction.id &&
+                TransactionDeduplication.isSameUpiTransaction(candidate, transaction)
+        }
+    }
+
+    suspend fun findGPayDuplicateIdsForCleanup(): List<Long> {
+        val candidates = transactionDao.findPotentialDuplicatesByReference()
+        return TransactionDeduplication.duplicateIdsToDelete(candidates)
     }
 }

--- a/app/src/main/java/com/ritesh/cashiro/domain/repository/RuleRepository.kt
+++ b/app/src/main/java/com/ritesh/cashiro/domain/repository/RuleRepository.kt
@@ -23,4 +23,5 @@ interface RuleRepository {
     suspend fun getRuleApplicationsForTransaction(transactionId: String): List<RuleApplication>
     fun getRuleApplicationsForRule(ruleId: String): Flow<List<RuleApplication>>
     suspend fun getRuleApplicationCount(ruleId: String): Int
+    suspend fun deleteRuleApplicationsForTransaction(transactionId: String)
 }

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/transactions/TransactionDetailScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material.icons.automirrored.filled.TrendingDown
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material.icons.filled.SubdirectoryArrowRight
@@ -2204,6 +2205,23 @@ private fun TransactionReceipt(
                              } else null
                         }
                     )
+
+                    val referenceValue = transaction.reference ?: transaction.smsSender
+                    if (referenceValue != null) {
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                        ReceiptInfoRow(
+                            label = "Reference",
+                            value = referenceValue,
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Default.Tag,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+                        )
+                    }
 
                     val fromAccount = transaction.fromAccount ?: transaction.accountNumber
                     val toAccount = transaction.toAccount

--- a/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
@@ -22,6 +22,7 @@ import com.ritesh.cashiro.data.repository.TransactionRepository
 import com.ritesh.cashiro.data.repository.UnrecognizedSmsRepository
 import com.ritesh.cashiro.domain.repository.RuleRepository
 import com.ritesh.cashiro.domain.service.RuleEngine
+import com.ritesh.cashiro.data.manager.TransactionDeduplication
 import com.ritesh.cashiro.utils.CurrencyFormatter
 import com.ritesh.parser.core.ParsedTransaction
 import com.ritesh.parser.core.bank.BankParserFactory
@@ -81,6 +82,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         val parsed = AtomicInteger(0)
         val saved = AtomicInteger(0)
         val blocked = AtomicInteger(0)
+        val duplicates = AtomicInteger(0)
         val subscription = AtomicInteger(0)
         private val startMs = System.currentTimeMillis()
 
@@ -103,6 +105,13 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         val body: String,
         val type: Int
     )
+
+    private enum class SaveOutcome {
+        SAVED,
+        UPDATED_DUPLICATE,
+        SKIPPED_DUPLICATE,
+        SKIPPED
+    }
 
     private sealed interface ParseResult {
         data class Regular(val parsed: ParsedTransaction, val sms: SmsMessage) : ParseResult
@@ -198,8 +207,17 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
                         stats.subscription.incrementAndGet()
                     }
                     is ParseResult.Regular -> {
-                        if (saveTransaction(result.parsed, result.sms, merchantMappingCache, ruleCache)) {
-                            stats.saved.incrementAndGet()
+                        when (saveTransaction(result.parsed, result.sms, merchantMappingCache, ruleCache, stats)) {
+                            SaveOutcome.SAVED -> {
+                                stats.saved.incrementAndGet()
+                            }
+                            SaveOutcome.UPDATED_DUPLICATE -> {
+                                stats.duplicates.incrementAndGet()
+                            }
+                            SaveOutcome.SKIPPED_DUPLICATE -> {
+                                stats.duplicates.incrementAndGet()
+                            }
+                            SaveOutcome.SKIPPED -> Unit
                         }
                     }
                 }
@@ -315,16 +333,19 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         parsed: ParsedTransaction,
         sms: SmsMessage,
         merchantMappingCache: Map<String, String>,
-        ruleCache: Map<com.ritesh.cashiro.data.database.entity.TransactionType, List<com.ritesh.cashiro.data.database.entity.RuleEntity>>
-    ): Boolean {
+        ruleCache: Map<com.ritesh.cashiro.data.database.entity.TransactionType, List<com.ritesh.cashiro.domain.model.rule.TransactionRule>>,
+        stats: ProcessingStats
+    ): SaveOutcome {
         return try {
             val entity = parsed.toEntity()
-            if (transactionRepository.getTransactionByHash(entity.transactionHash) != null) return false
+            if (transactionRepository.getTransactionByHash(entity.transactionHash) != null) return SaveOutcome.SKIPPED
 
-            val mapped = merchantMappingCache[entity.merchantName]?.let { entity.copy(category = it) } ?: entity
+            val customCategory = merchantMappingCache[entity.merchantName]
+            val mapped = if (customCategory != null) entity.copy(category = customCategory) else entity
             val activeRules = ruleCache[mapped.transactionType] ?: emptyList()
             if (ruleEngine.shouldBlockTransaction(mapped, sms.body, activeRules) != null) {
-                return false
+                stats.blocked.incrementAndGet()
+                return SaveOutcome.SKIPPED
             }
 
             val (withRules, ruleApps) = ruleEngine.evaluateRules(mapped, sms.body, activeRules)
@@ -334,15 +355,34 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
                 withRules.copy(isRecurring = true)
             } else withRules
 
-            val rowId = transactionRepository.insertTransaction(finalEntity)
-            if (rowId == -1L) return false
+            val duplicate = transactionRepository.findPotentialDuplicates(finalEntity).firstOrNull()
+            if (duplicate != null) {
+                if (TransactionDeduplication.shouldReplaceWithIncoming(duplicate, finalEntity)) {
+                    val replacement = finalEntity.copy(
+                        id = duplicate.id,
+                        transactionHash = duplicate.transactionHash,
+                        isRecurring = duplicate.isRecurring || finalEntity.isRecurring,
+                        createdAt = duplicate.createdAt
+                    )
+                    transactionRepository.updateTransaction(replacement)
+                    accountBalanceRepository.deleteBalancesForTransaction(duplicate.id)
+                    replaceRuleApplications(duplicate.id, ruleApps)
+                    processBalanceUpdate(parsed, replacement, duplicate.id)
+                    return SaveOutcome.UPDATED_DUPLICATE
+                }
+                return SaveOutcome.SKIPPED_DUPLICATE
+            }
 
-            if (ruleApps.isNotEmpty()) ruleRepository.saveRuleApplications(ruleApps)
+            val rowId = transactionRepository.insertTransaction(finalEntity)
+            if (rowId == -1L) return SaveOutcome.SKIPPED
+
+            saveRuleApplications(rowId, ruleApps)
             processBalanceUpdate(parsed, finalEntity, rowId)
-            true
+            SaveOutcome.SAVED
+
         } catch (e: Exception) {
             Log.e(TAG, "Error saving transaction: ${e.message}")
-            false
+            SaveOutcome.SKIPPED
         }
     }
 
@@ -400,6 +440,24 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         Log.i(TAG, "Balance saved for ${parsed.bankName} **$targetAccount: ${CurrencyFormatter.formatCurrency(newBalance, parsed.currency)}")
     }
 
+    private suspend fun replaceRuleApplications(
+        transactionId: Long,
+        ruleApps: List<com.ritesh.cashiro.domain.model.rule.RuleApplication>
+    ) {
+        ruleRepository.deleteRuleApplicationsForTransaction(transactionId.toString())
+        saveRuleApplications(transactionId, ruleApps)
+    }
+
+    private suspend fun saveRuleApplications(
+        transactionId: Long,
+        ruleApps: List<com.ritesh.cashiro.domain.model.rule.RuleApplication>
+    ) {
+        if (ruleApps.isEmpty()) return
+        ruleRepository.saveRuleApplications(
+            ruleApps.map { it.copy(transactionId = transactionId.toString()) }
+        )
+    }
+
     private suspend fun flushUnrecognizedBatch(batch: ArrayList<SmsMessage>) {
         for (sms in batch) {
             try {
@@ -421,9 +479,27 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
 
     private suspend fun cleanUpAndFinalize(stats: ProcessingStats) {
         try { unrecognizedSmsRepository.cleanupOldEntries() } catch (e: Exception) { Log.e(TAG, "Cleanup error: ${e.message}") }
+        try {
+            val deletedDuplicates = cleanupExistingGPayDuplicates()
+            if (deletedDuplicates > 0) {
+                Log.i(TAG, "Cleaned up $deletedDuplicates existing GPay duplicate transactions")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "GPay duplicate cleanup error: ${e.message}")
+        }
         if (stats.saved.get() > 0) {
             try { llmRepository.updateSystemPrompt() } catch (e: Exception) { Log.e(TAG, "Prompt update error: ${e.message}") }
         }
+    }
+
+    private suspend fun cleanupExistingGPayDuplicates(): Int {
+        val duplicateIds = transactionRepository.findGPayDuplicateIdsForCleanup()
+        duplicateIds.forEach { id ->
+            transactionRepository.deleteTransactionById(id)
+            accountBalanceRepository.deleteBalancesForTransaction(id)
+            ruleRepository.deleteRuleApplicationsForTransaction(id.toString())
+        }
+        return duplicateIds.size
     }
 
     private suspend fun reportProgress(stats: ProcessingStats) {
@@ -500,7 +576,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
     private fun readRcsMessages(scanStartSeconds: Long): List<SmsMessage> {
         val result = mutableListOf<SmsMessage>()
         applicationContext.contentResolver.query(
-            "content://mms".toUri(), arrayOf("_id", "thread_id", "date", "tr_id", "m_id"),
+            Uri.parse("content://mms"), arrayOf("_id", "thread_id", "date", "tr_id", "m_id"),
             "date >= ?", arrayOf(scanStartSeconds.toString()), "date DESC"
         )?.use { c ->
             while (c.moveToNext()) {
@@ -531,7 +607,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
     } catch (_: Exception) { null }
 
     private fun getRcsMessageText(messageId: Long): String? = try {
-        applicationContext.contentResolver.query("content://mms/part".toUri(), null, "mid = ?", arrayOf(messageId.toString()), null)?.use { c ->
+        applicationContext.contentResolver.query(Uri.parse("content://mms/part"), null, "mid = ?", arrayOf(messageId.toString()), null)?.use { c ->
             while (c.moveToNext()) {
                 val ct = c.getColumnIndex("ct").takeIf { it >= 0 }?.let { c.getString(it) } ?: continue
                 if (!ct.startsWith("text/") && ct != "application/smil") continue
@@ -540,7 +616,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
                 }
                 val partId = c.getLong(c.getColumnIndexOrThrow("_id"))
                 try {
-                    applicationContext.contentResolver.openInputStream("content://mms/part/$partId".toUri())
+                    applicationContext.contentResolver.openInputStream(Uri.parse("content://mms/part/$partId"))
                         ?.bufferedReader()?.use { it.readText() }?.takeIf { it.isNotEmpty() }?.let { return it }
                 } catch (_: Exception) {}
             }
@@ -577,6 +653,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         │  Processed : ${stats.processed.get()}
         │  Parsed    : ${stats.parsed.get()}
         │  Saved     : ${stats.saved.get()}
+        │  Duplicates: ${stats.duplicates.get()}
         │  Elapsed   : ${stats.elapsedMs()}ms
         │  Speed     : ${"%.1f".format(stats.msgPerSec())} msg/s
         └──────────────────────────────────────────────

--- a/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
@@ -8,17 +8,8 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
-import com.ritesh.parser.core.ParsedTransaction
-import com.ritesh.parser.core.bank.BankParserFactory
-import com.ritesh.parser.core.bank.FederalBankParser
-import com.ritesh.parser.core.bank.HDFCBankParser
-import com.ritesh.parser.core.bank.IndianBankParser
-import com.ritesh.parser.core.bank.SBIBankParser
-import com.ritesh.parser.core.bank.IndusIndBankParser
-import com.ritesh.parser.core.SmsFilter
 import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
-import com.ritesh.cashiro.data.database.entity.UnrecognizedSmsEntity
 import com.ritesh.cashiro.data.mapper.toEntity
 import com.ritesh.cashiro.data.mapper.toEntityType
 import com.ritesh.cashiro.data.preferences.UserPreferencesRepository
@@ -32,31 +23,24 @@ import com.ritesh.cashiro.data.repository.UnrecognizedSmsRepository
 import com.ritesh.cashiro.domain.repository.RuleRepository
 import com.ritesh.cashiro.domain.service.RuleEngine
 import com.ritesh.cashiro.utils.CurrencyFormatter
+import com.ritesh.parser.core.ParsedTransaction
+import com.ritesh.parser.core.bank.BankParserFactory
+import com.ritesh.parser.core.bank.FederalBankParser
+import com.ritesh.parser.core.bank.HDFCBankParser
+import com.ritesh.parser.core.bank.IndianBankParser
+import com.ritesh.parser.core.bank.IndusIndBankParser
+import com.ritesh.parser.core.bank.SBIBankParser
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import kotlin.system.measureTimeMillis
+import java.util.concurrent.atomic.AtomicInteger
 
-/**
- * Optimized SMS Worker with parallel processing and progress tracking.
- * This worker provides significant performance improvements through:
- * 1. Parallel processing of SMS messages
- * 2. Progress reporting with estimated time completion
- * 3. Optimized database operations
- * 4. Efficient memory usage
- */
 @HiltWorker
 class OptimizedSmsReaderWorker @AssistedInject constructor(
     @Assisted appContext: Context,
@@ -76,11 +60,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
     companion object {
         const val TAG = "OptimizedSmsReaderWorker"
         const val WORK_NAME = "optimized_sms_reader_work"
-
-        // Input keys
         const val INPUT_FORCE_RESYNC = "input_force_resync"
-
-        // Progress keys
         const val PROGRESS_TOTAL = "progress_total"
         const val PROGRESS_PROCESSED = "progress_processed"
         const val PROGRESS_PARSED = "progress_parsed"
@@ -88,1661 +68,519 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         const val PROGRESS_BLOCKED = "progress_blocked"
         const val PROGRESS_TIME_ELAPSED = "progress_time_elapsed"
         const val PROGRESS_ESTIMATED_TIME_REMAINING = "progress_estimated_time_remaining"
+        const val PROGRESS_ETA_SECONDS = "progress_eta_seconds"
+        const val PROGRESS_MSG_PER_SEC = "progress_msg_per_sec"
         const val PROGRESS_CURRENT_BATCH = "progress_current_batch"
         const val PROGRESS_TOTAL_BATCHES = "progress_total_batches"
-
-        // SMS Content Provider columns
-        private val SMS_PROJECTION = arrayOf(
-            Telephony.Sms._ID,
-            Telephony.Sms.ADDRESS,
-            Telephony.Sms.DATE,
-            Telephony.Sms.BODY,
-            Telephony.Sms.TYPE
-        )
-
-        // Parallel processing configuration
-        private const val PROGRESS_REPORT_INTERVAL = 10 // Report progress every 10 messages
+        const val PROGRESS_REPORT_FREQUENCY = 25
+        private val SMS_PROJECTION = arrayOf(Telephony.Sms._ID, Telephony.Sms.ADDRESS, Telephony.Sms.DATE, Telephony.Sms.BODY, Telephony.Sms.TYPE)
     }
 
-    /**
-     * Calculates optimal batch size based on available cores and total messages
-     */
-    private fun calculateOptimalBatchSize(totalMessages: Int, availableCores: Int): Int {
-        return when {
-            totalMessages < 100 -> 10 // Small datasets: small batches for better progress tracking
-            totalMessages < 500 -> 25 // Medium datasets: moderate batches
-            totalMessages < 2000 -> 50 // Large datasets: standard batches
-            else -> {
-                // Very large datasets: scale batch size with cores but cap at reasonable limit
-                val coreBasedBatch = availableCores * 15
-                minOf(coreBasedBatch, 200)
-            }
+    private class ProcessingStats(val total: Int) {
+        val processed = AtomicInteger(0)
+        val parsed = AtomicInteger(0)
+        val saved = AtomicInteger(0)
+        val blocked = AtomicInteger(0)
+        val subscription = AtomicInteger(0)
+        private val startMs = System.currentTimeMillis()
+
+        fun elapsedMs() = System.currentTimeMillis() - startMs
+        fun msgPerSec(): Double {
+            val sec = elapsedMs() / 1000.0
+            return if (sec > 0) processed.get() / sec else 0.0
+        }
+
+        fun etaSec(): Long {
+            val rate = msgPerSec()
+            return if (rate > 0) ((total - processed.get()) / rate).toLong() else 0L
         }
     }
 
-    /**
-     * Calculates optimal parallelism based on available cores and message count
-     *
-     * IMPORTANT: Sequential processing (parallelism=1) to prevent race conditions
-     * in balance calculations. When multiple threads process transactions for the
-     * same account simultaneously, they read the same "previous balance" value,
-     * causing incorrect balance calculations.
-     */
-    private fun calculateOptimalParallelism(totalMessages: Int, availableCores: Int): Int {
-        // Always use sequential processing to ensure correct balance calculations
-        return 1
-    }
+    private data class SmsMessage(
+        val id: Long,
+        val sender: String,
+        val timestamp: Long,
+        val body: String,
+        val type: Int
+    )
 
-    data class ProcessingStats(
-        var totalMessages: Int = 0,
-        var processedMessages: Int = 0,
-        var parsedTransactions: Int = 0,
-        var savedTransactions: Int = 0,
-        var blockedTransactions: Int = 0,
-        var subscriptionCount: Int = 0,
-        var startTime: Long = System.currentTimeMillis(),
-        var messagesPerSecond: Double = 0.0
-    ) {
-        fun updateTimeElapsed(): Long = System.currentTimeMillis() - startTime
-
-        fun updateMessagesPerSecond() {
-            val elapsedSeconds = updateTimeElapsed() / 1000.0
-            messagesPerSecond = if (elapsedSeconds > 0) processedMessages / elapsedSeconds else 0.0
-        }
-
-        fun getEstimatedTimeRemaining(): Long {
-            return if (messagesPerSecond > 0 && processedMessages > 0) {
-                val remainingMessages = totalMessages - processedMessages
-                (remainingMessages / messagesPerSecond * 1000).toLong()
-            } else 0L
-        }
+    private sealed interface ParseResult {
+        data class Regular(val parsed: ParsedTransaction, val sms: SmsMessage) : ParseResult
+        data class SpecialNotification(val sms: SmsMessage, val action: suspend () -> Unit) : ParseResult
     }
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
-            // Check if this is a force resync request
             val forceResync = inputData.getBoolean(INPUT_FORCE_RESYNC, false)
-            Log.d(TAG, "Starting optimized SMS reading and parsing work... (forceResync: $forceResync)")
+            Log.i(TAG, "Start — forceResync=$forceResync")
 
-            // If force resync, clear existing data first
             if (forceResync) {
-                Log.d(TAG, "Force resync: Clearing existing transactions and account balances...")
                 transactionRepository.deleteAllTransactions()
                 accountBalanceRepository.deleteAllBalances()
-                Log.d(TAG, "Force resync: Database cleared, starting fresh scan")
             }
 
-            val stats = ProcessingStats()
-
-            // Read SMS messages (force resync ignores last scan timestamp)
             val messages = readSmsMessages(forceResync)
-            stats.totalMessages = messages.size
-            Log.d(TAG, "Found ${messages.size} SMS messages to process")
+            if (messages.isEmpty()) { Log.i(TAG, "No messages to process"); return@withContext Result.success() }
 
-            // Calculate optimal batch size and parallelism based on available cores and message count
-            val availableCores = Runtime.getRuntime().availableProcessors()
-            val batchSize = calculateOptimalBatchSize(messages.size, availableCores)
-            val parallelism = calculateOptimalParallelism(messages.size, availableCores)
+            val stats = ProcessingStats(messages.size)
+            Log.i(TAG, "Messages to process: ${messages.size}")
 
-            Log.d(TAG, "Auto-calculated optimization parameters:")
-            Log.d(TAG, "- Available CPU cores: $availableCores")
-            Log.d(TAG, "- Batch size: $batchSize")
-            Log.d(TAG, "- Parallelism: $parallelism")
-            Log.d(TAG, "- Total batches: ${(messages.size + batchSize - 1) / batchSize}")
+            processPipeline(messages, stats)
+            cleanUpAndFinalize(stats)
 
-            // Debug: Log first 20 unique senders to understand what we're working with
-            val uniqueSenders = messages.take(50).map { it.sender }.distinct()
-            Log.d(TAG, "First 20 unique senders: ${uniqueSenders.joinToString(", ")}")
-
-            // Debug: Check for any FAB-related senders
-            val fabSenders = messages.map { it.sender }.filter {
-                it.uppercase().contains("FAB") ||
-                        it.uppercase().contains("ABU DHABI") ||
-                        it.uppercase().contains("FIRST ABU DHABI")
-            }.distinct()
-            Log.d(TAG, "Found FAB-related senders: ${fabSenders.joinToString(", ")}")
-
-            // Report initial progress
-            setProgress(
-                workDataOf(
-                    PROGRESS_TOTAL to messages.size,
-                    PROGRESS_PROCESSED to 0,
-                    PROGRESS_PARSED to 0,
-                    PROGRESS_SAVED to 0,
-                    PROGRESS_TIME_ELAPSED to 0L,
-                    PROGRESS_ESTIMATED_TIME_REMAINING to 0L,
-                    PROGRESS_CURRENT_BATCH to 1,
-                    PROGRESS_TOTAL_BATCHES to (messages.size + batchSize - 1) / batchSize
-                )
-            )
-
-            // Process messages in parallel for maximum speed
-            val processingTime = measureTimeMillis {
-                processMessagesInParallel(messages, stats, batchSize, parallelism)
-            }
-
-            stats.updateTimeElapsed()
-            stats.updateMessagesPerSecond()
-
-            Log.d(
-                TAG, """
-                SMS parsing completed in ${processingTime}ms:
-                - Total Messages: ${stats.totalMessages}
-                - Processed: ${stats.processedMessages}
-                - Parsed Transactions: ${stats.parsedTransactions}
-                - Saved Transactions: ${stats.savedTransactions}
-                - Subscriptions: ${stats.subscriptionCount}
-                - Processing Speed: ${"%.2f".format(stats.messagesPerSecond)} msg/sec
-            """.trimIndent()
-            )
-
-            // Clean up old unrecognized SMS entries
-            try {
-                unrecognizedSmsRepository.cleanupOldEntries()
-                Log.d(TAG, "Cleaned up old unrecognized SMS entries")
-            } catch (e: Exception) {
-                Log.e(TAG, "Error cleaning up unrecognized SMS: ${e.message}")
-            }
-
-            // Update system prompt with new financial data if any transactions were saved
-            if (stats.savedTransactions > 0) {
-                try {
-                    llmRepository.updateSystemPrompt()
-                    Log.d(TAG, "Updated system prompt with latest financial data")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error updating system prompt: ${e.message}")
-                }
-            }
-
-            // Report final progress
-            setProgress(
-                workDataOf(
-                    PROGRESS_TOTAL to messages.size,
-                    PROGRESS_PROCESSED to messages.size,
-                    PROGRESS_PARSED to stats.parsedTransactions,
-                    PROGRESS_SAVED to stats.savedTransactions,
-                    PROGRESS_TIME_ELAPSED to stats.updateTimeElapsed(),
-                    PROGRESS_ESTIMATED_TIME_REMAINING to 0L,
-                    PROGRESS_CURRENT_BATCH to (messages.size + batchSize - 1) / batchSize,
-                    PROGRESS_TOTAL_BATCHES to (messages.size + batchSize - 1) / batchSize
-                )
-            )
-
+            Log.i(TAG, buildSummary(stats))
             Result.success()
         } catch (e: Exception) {
-            Log.e(TAG, "Error in optimized SMS parsing work", e)
+            Log.e(TAG, "Fatal error", e)
             Result.failure()
         }
     }
 
-    private suspend fun processMessagesSequentially(
-        messages: List<SmsMessage>,
-        stats: ProcessingStats,
-        batchSize: Int
-    ) {
-        val totalBatches = (messages.size + batchSize - 1) / batchSize
-
-        messages.chunked(batchSize).forEachIndexed { batchIndex, batch ->
-            var parsedCount = 0
-            var savedCount = 0
-            var subscriptionCount = 0
-
-            for (sms in batch) {
-                try {
-                    // Skip promotional (-P) and government (-G) messages
-                    // Exception: Allow known banks like DOP that use -G sender IDs
-                    val senderUpper = sms.sender.uppercase()
-                    val isKnownBank = BankParserFactory.isKnownBankSender(sms.sender)
-                    if ((senderUpper.endsWith("-P") || senderUpper.endsWith("-G")) && !isKnownBank) {
-                        Log.d(TAG, "Skipping promotional/government SMS from: ${sms.sender}")
-                        continue
-                    }
-
-                    val parser = BankParserFactory.getParser(sms.sender)
-                    if (parser != null) {
-                        Log.d(
-                            TAG,
-                            "Found parser: ${parser.getBankName()} for sender: ${sms.sender}"
-                        )
-                        // Check if this is a subscription notification first
-                        val smsDateTime = java.time.LocalDateTime.ofInstant(
-                            java.time.Instant.ofEpochMilli(sms.timestamp),
-                            java.time.ZoneId.systemDefault()
-                        )
-                        val thirtyDaysAgo = java.time.LocalDateTime.now().minusDays(30)
-                        val isRecentMessage = smsDateTime.isAfter(thirtyDaysAgo)
-                        val subscriptionResult = processSubscriptionNotifications(
-                            parser,
-                            sms,
-                            smsDateTime,
-                            isRecentMessage
-                        )
-                        subscriptionCount += subscriptionResult.subscriptionCount
-
-                        if (subscriptionResult.shouldSkipTransaction) {
-                            // This was a subscription/balance update notification, skip transaction parsing
-                            continue
-                        }
-
-                        // Parse as regular transaction
-                        val parsedTransaction = parser.parse(sms.body, sms.sender, sms.timestamp)
-                        if (parsedTransaction != null) {
-                            parsedCount++
-                            Log.d(
-                                TAG, """
-                                Parsed Transaction:
-                                Bank: ${parsedTransaction.bankName}
-                                Amount: ${parsedTransaction.amount}
-                                Type: ${parsedTransaction.type}
-                                Merchant: ${parsedTransaction.merchant}
-                                Reference: ${parsedTransaction.reference}
-                                Account: ${parsedTransaction.accountLast4}
-                                Balance: ${parsedTransaction.balance}
-                                Credit Limit: ${parsedTransaction.creditLimit}
-                                ID: ${parsedTransaction.generateTransactionId()}
-                            """.trimIndent()
-                            )
-
-                            // Save transaction to database
-                            val success = saveParsedTransaction(parsedTransaction, sms)
-                            if (success) {
-                                savedCount++
-                                Log.d(TAG, "Saved transaction successfully")
-                            }
-                        } else {
-                            // Log some sample unparsed messages for debugging
-                            if (batch.indexOf(sms) < 3) { // Only log first 3 to avoid spam
-                                Log.d(
-                                    TAG,
-                                    "Failed to parse SMS from ${sms.sender}: ${sms.body.take(100)}..."
-                                )
-                            }
-                        }
-                    } else {
-                        // Check if it's from a potential financial provider (-T or -S suffix)
-                        val upperSender = sms.sender.uppercase()
-                        if (upperSender.endsWith("-T") || upperSender.endsWith("-S")) {
-                            processUnrecognizedSms(sms)
-                        } else {
-                            // Log ALL unrecognized senders for debugging (but limit first batch)
-                            if (batch.indexOf(sms) < 10) { // Log first 10 of each batch
-                                Log.d(TAG, "No parser found for sender: ${sms.sender}")
-                            }
-                        }
-                    }
-                }
-                    catch (e: Exception) {
-                        Log.e(TAG, "Error processing SMS from ${sms.sender}: ${e.message}")
-                    }
-
-        }
-
-        // Update stats
-        stats.processedMessages += batch.size
-        stats.parsedTransactions += parsedCount
-        stats.savedTransactions += savedCount
-        stats.subscriptionCount += subscriptionCount
-
-        // Update progress
-        stats.updateMessagesPerSecond()
-        if (stats.processedMessages % PROGRESS_REPORT_INTERVAL == 0 || stats.processedMessages == stats.totalMessages) {
-            try {
-                setProgress(
-                    workDataOf(
-                        PROGRESS_TOTAL to stats.totalMessages,
-                        PROGRESS_PROCESSED to stats.processedMessages,
-                        PROGRESS_PARSED to stats.parsedTransactions,
-                        PROGRESS_SAVED to stats.savedTransactions,
-                        PROGRESS_TIME_ELAPSED to stats.updateTimeElapsed(),
-                        PROGRESS_ESTIMATED_TIME_REMAINING to stats.getEstimatedTimeRemaining(),
-                        PROGRESS_CURRENT_BATCH to batchIndex + 1,
-                        PROGRESS_TOTAL_BATCHES to totalBatches
-                    )
-                )
-            } catch (e: Exception) {
-                Log.e(TAG, "Error setting progress: ${e.message}")
-            }
-        }
-    }
-}
-
-private suspend fun processMessagesInParallel(
-    messages: List<SmsMessage>,
-    stats: ProcessingStats,
-    batchSize: Int,
-    parallelism: Int
-) = coroutineScope {
-    val totalBatches = (messages.size + batchSize - 1) / batchSize
-
-    // Use atomic counters for real-time progress tracking
-    val atomicProcessed = java.util.concurrent.atomic.AtomicInteger(0)
-    val atomicParsed = java.util.concurrent.atomic.AtomicInteger(0)
-    val atomicSaved = java.util.concurrent.atomic.AtomicInteger(0)
-
-    // Create parallel processing coroutines that return results directly
-    val processingJobs = (1..parallelism).map { coroutineId ->
-        async(Dispatchers.IO) {
-            processBatchCoroutinesDirect(
-                messages,
-                coroutineId,
-                totalBatches,
-                stats,
-                atomicProcessed,
-                atomicParsed,
-                atomicSaved,
-                batchSize,
-                parallelism
-            )
-        }
-    }
-
-    // Create progress monitoring coroutine that reads atomic counters
-    val progressJob = launch(Dispatchers.IO) {
-        var lastReportedProcessed = 0
-
-        while (atomicProcessed.get() < stats.totalMessages) {
-            val currentProcessed = atomicProcessed.get()
-            val currentParsed = atomicParsed.get()
-            val currentSaved = atomicSaved.get()
-
-            // Update stats and report progress every few messages or time interval
-            if (currentProcessed - lastReportedProcessed >= PROGRESS_REPORT_INTERVAL ||
-                currentProcessed >= stats.totalMessages
-            ) {
-
-                stats.processedMessages = currentProcessed
-                stats.parsedTransactions = currentParsed
-                stats.savedTransactions = currentSaved
-                stats.updateMessagesPerSecond()
-
-                setProgress(
-                    workDataOf(
-                        PROGRESS_TOTAL to stats.totalMessages,
-                        PROGRESS_PROCESSED to currentProcessed,
-                        PROGRESS_PARSED to currentParsed,
-                        PROGRESS_SAVED to currentSaved,
-                        PROGRESS_TIME_ELAPSED to stats.updateTimeElapsed(),
-                        PROGRESS_ESTIMATED_TIME_REMAINING to stats.getEstimatedTimeRemaining(),
-                        PROGRESS_CURRENT_BATCH to (currentProcessed + batchSize - 1) / batchSize,
-                        PROGRESS_TOTAL_BATCHES to totalBatches
-                    )
-                )
-
-                lastReportedProcessed = currentProcessed
-            }
-
-            delay(50) // Check every 50ms for smooth updates
-        }
-    }
-
-    // Wait for all jobs to complete
-    val results = processingJobs.awaitAll()
-    progressJob.cancel()
-
-    // Aggregate final results
-    results.forEach { result ->
-        stats.parsedTransactions += result.parsedCount
-        stats.savedTransactions += result.savedCount
-        stats.subscriptionCount += result.subscriptionCount
-    }
-
-    // Final progress update
-    stats.processedMessages = stats.totalMessages
-    stats.updateMessagesPerSecond()
-    setProgress(
-        workDataOf(
-            PROGRESS_TOTAL to stats.totalMessages,
-            PROGRESS_PROCESSED to stats.processedMessages,
-            PROGRESS_PARSED to stats.parsedTransactions,
-            PROGRESS_SAVED to stats.savedTransactions,
-            PROGRESS_TIME_ELAPSED to stats.updateTimeElapsed(),
-            PROGRESS_ESTIMATED_TIME_REMAINING to 0L,
-            PROGRESS_CURRENT_BATCH to totalBatches,
-            PROGRESS_TOTAL_BATCHES to totalBatches
+    private suspend fun processPipeline(messages: List<SmsMessage>, stats: ProcessingStats) = coroutineScope {
+        val merchantMappingCache = merchantMappingRepository.getAllMappingsAsMap()
+        val ruleCache = mapOf(
+            com.ritesh.cashiro.data.database.entity.TransactionType.INCOME to
+                    ruleRepository.getActiveRulesByType(com.ritesh.cashiro.data.database.entity.TransactionType.INCOME),
+            com.ritesh.cashiro.data.database.entity.TransactionType.EXPENSE to
+                    ruleRepository.getActiveRulesByType(com.ritesh.cashiro.data.database.entity.TransactionType.EXPENSE),
+            com.ritesh.cashiro.data.database.entity.TransactionType.CREDIT to
+                    ruleRepository.getActiveRulesByType(com.ritesh.cashiro.data.database.entity.TransactionType.CREDIT),
+            com.ritesh.cashiro.data.database.entity.TransactionType.TRANSFER to
+                    ruleRepository.getActiveRulesByType(com.ritesh.cashiro.data.database.entity.TransactionType.TRANSFER),
+            com.ritesh.cashiro.data.database.entity.TransactionType.INVESTMENT to
+                    ruleRepository.getActiveRulesByType(com.ritesh.cashiro.data.database.entity.TransactionType.INVESTMENT)
         )
-    )
-}
 
-private suspend fun processBatchCoroutines(
-    messages: List<SmsMessage>,
-    coroutineId: Int,
-    totalBatches: Int,
-    stats: ProcessingStats,
-    resultsChannel: Channel<ProcessingResult>,
-    batchSize: Int,
-    parallelism: Int
-) {
-    val messageBatchSize = (messages.size + parallelism - 1) / parallelism
-    val startIndex = (coroutineId - 1) * messageBatchSize
-    val endIndex = minOf(startIndex + messageBatchSize, messages.size)
+        val parseChannel = Channel<ParseResult>(capacity = Channel.BUFFERED)
+        val unrecognizedBatch = ArrayList<SmsMessage>()
 
-    if (startIndex >= messages.size) return
+        val parseJob = launch(Dispatchers.IO) {
+            for (sms in messages) {
+                stats.processed.incrementAndGet()
 
-    val assignedMessages = messages.subList(startIndex, endIndex)
-
-    // Process assigned messages in smaller chunks
-    for (i in assignedMessages.indices step batchSize) {
-        val chunkEnd = minOf(i + batchSize, assignedMessages.size)
-        val chunk = assignedMessages.subList(i, chunkEnd)
-
-        val result = processMessageChunk(chunk, coroutineId, i / batchSize + 1)
-        resultsChannel.send(result)
-    }
-}
-
-private suspend fun processMessageChunk(
-    messages: List<SmsMessage>,
-    coroutineId: Int,
-    batchNumber: Int
-): ProcessingResult {
-    var parsedCount = 0
-    var savedCount = 0
-    var subscriptionCount = 0
-
-    for (sms in messages) {
-        try {
-            // Skip promotional (-P) and government (-G) messages
-            // Exception: Allow known banks like DOP that use -G sender IDs
-            val senderUpper = sms.sender.uppercase()
-            val isKnownBank = BankParserFactory.isKnownBankSender(sms.sender)
-            if ((senderUpper.endsWith("-P") || senderUpper.endsWith("-G")) && !isKnownBank) {
-                continue
-            }
-
-            // Check if sender is from a known bank
-            val parser = BankParserFactory.getParser(sms.sender)
-            if (parser != null) {
-                Log.d(TAG, "Processing SMS from ${parser.getBankName()}")
-                // Calculate SMS age for subscription filtering
-                val smsDateTime = LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(sms.timestamp),
-                    ZoneId.systemDefault()
-                )
-                val thirtyDaysAgo = LocalDateTime.now().minusDays(30)
-                val isRecentMessage = smsDateTime.isAfter(thirtyDaysAgo)
-
-                // Process subscription notifications
-                val subscriptionResult =
-                    processSubscriptionNotifications(parser, sms, smsDateTime, isRecentMessage)
-                subscriptionCount += subscriptionResult.subscriptionCount
-                if (subscriptionResult.shouldSkipTransaction) {
-                    continue
-                }
-
-                // Parse the transaction
-                val parsedTransaction = parser.parse(sms.body, sms.sender, sms.timestamp)
-
-                if (parsedTransaction != null) {
-                    parsedCount++
-                    Log.d(
-                        TAG, """
-                            Parsed Transaction:
-                            Bank: ${parsedTransaction.bankName}
-                            Amount: ${parsedTransaction.amount}
-                            Type: ${parsedTransaction.type}
-                            Merchant: ${parsedTransaction.merchant}
-                            Reference: ${parsedTransaction.reference}
-                            Account: ${parsedTransaction.accountLast4}
-                            Balance: ${parsedTransaction.balance}
-                            Credit Limit: ${parsedTransaction.creditLimit}
-                            ID: ${parsedTransaction.generateTransactionId()}
-                        """.trimIndent()
-                    )
-
-                    val saveResult = saveParsedTransaction(parsedTransaction, sms)
-                    if (saveResult) savedCount++
-                } else {
-                    // Log some sample unparsed messages for debugging
-                    Log.d(TAG, "Failed to parse SMS from ${sms.sender}: ${sms.body.take(100)}...")
-                }
-            } else {
-                // Handle unrecognized SMS
-                processUnrecognizedSms(sms)
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error processing SMS from ${sms.sender}: ${e.message}")
-        }
-    }
-
-    return ProcessingResult(
-        processedCount = messages.size,
-        parsedCount = parsedCount,
-        savedCount = savedCount,
-        subscriptionCount = subscriptionCount,
-        coroutineId = coroutineId,
-        batchNumber = batchNumber
-    )
-}
-
-private suspend fun processBatchCoroutinesDirect(
-    messages: List<SmsMessage>,
-    coroutineId: Int,
-    totalBatches: Int,
-    stats: ProcessingStats,
-    atomicProcessed: java.util.concurrent.atomic.AtomicInteger,
-    atomicParsed: java.util.concurrent.atomic.AtomicInteger,
-    atomicSaved: java.util.concurrent.atomic.AtomicInteger,
-    batchSize: Int,
-    parallelism: Int
-): ProcessingResult {
-    var parsedCount = 0
-    var savedCount = 0
-    var subscriptionCount = 0
-
-    // Calculate batch assignments for this coroutine
-    val batchesPerCoroutine = (totalBatches + parallelism - 1) / parallelism
-    val startBatch = (coroutineId - 1) * batchesPerCoroutine
-    val endBatch = minOf(startBatch + batchesPerCoroutine, totalBatches)
-
-    // Process assigned batches
-    for (batchIndex in startBatch until endBatch) {
-        val startIndex = batchIndex * batchSize
-        val endIndex = minOf(startIndex + batchSize, messages.size)
-        val batch = messages.subList(startIndex, endIndex)
-
-        for (sms in batch) {
-            try {
-                // Update processed count immediately for real-time progress
-                atomicProcessed.incrementAndGet()
-
-                // Skip promotional (-P) and government (-G) messages
-                // Exception: Allow known banks like DOP that use -G sender IDs
                 val senderUpper = sms.sender.uppercase()
                 val isKnownBank = BankParserFactory.isKnownBankSender(sms.sender)
-                if ((senderUpper.endsWith("-P") || senderUpper.endsWith("-G")) && !isKnownBank) {
+                if ((senderUpper.endsWith("-P") || senderUpper.endsWith("-G")) && !isKnownBank) continue
+
+                val parser = BankParserFactory.getParser(sms.sender)
+                if (parser == null) {
+                    val upperSender = sms.sender.uppercase()
+                    if (upperSender.endsWith("-T") || upperSender.endsWith("-S")) {
+                        unrecognizedBatch.add(sms)
+                    }
                     continue
                 }
 
-                val parser = BankParserFactory.getParser(sms.sender)
-                if (parser != null) {
-                    Log.d(TAG, "Processing SMS from ${parser.getBankName()}")
-                    // Check if this is a subscription notification first
-                    val smsDateTime = java.time.LocalDateTime.ofInstant(
-                        java.time.Instant.ofEpochMilli(sms.timestamp),
-                        java.time.ZoneId.systemDefault()
-                    )
-                    val thirtyDaysAgo = java.time.LocalDateTime.now().minusDays(30)
-                    val isRecentMessage = smsDateTime.isAfter(thirtyDaysAgo)
-                    val subscriptionResult =
-                        processSubscriptionNotifications(parser, sms, smsDateTime, isRecentMessage)
-                    subscriptionCount += subscriptionResult.subscriptionCount
-
-                    if (subscriptionResult.shouldSkipTransaction) {
-                        // This was a subscription/balance update notification, skip transaction parsing
-                        continue
-                    }
-
-                    // Parse as regular transaction
-                    val parsedTransaction = parser.parse(sms.body, sms.sender, sms.timestamp)
-                    if (parsedTransaction != null) {
-                        parsedCount++
-                        atomicParsed.incrementAndGet()
-
-                        Log.d(
-                            TAG, """
-                                Parsed Transaction:
-                                Bank: ${parsedTransaction.bankName}
-                                Amount: ${parsedTransaction.amount}
-                                Type: ${parsedTransaction.type}
-                                Merchant: ${parsedTransaction.merchant}
-                                Reference: ${parsedTransaction.reference}
-                                Account: ${parsedTransaction.accountLast4}
-                                Balance: ${parsedTransaction.balance}
-                                Credit Limit: ${parsedTransaction.creditLimit}
-                                ID: ${parsedTransaction.generateTransactionId()}
-                            """.trimIndent()
-                        )
-
-                        // Save transaction to database
-                        val success = saveParsedTransaction(parsedTransaction, sms)
-                        if (success) {
-                            savedCount++
-                            atomicSaved.incrementAndGet()
-                        }
-                    } else {
-                        // Log some sample unparsed messages for debugging
-                        Log.d(
-                            TAG,
-                            "Failed to parse SMS from ${sms.sender}: ${sms.body.take(100)}..."
-                        )
-                    }
-                } else {
-                    // Handle unrecognized SMS
-                    processUnrecognizedSms(sms)
+                val subscriptionResult = processSubscription(parser, sms)
+                if (subscriptionResult != null) {
+                    parseChannel.send(subscriptionResult)
+                    continue
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error processing SMS from ${sms.sender}: ${e.message}")
+
+                val parsed = parser.parse(sms.body, sms.sender, sms.timestamp)
+                if (parsed != null) {
+                    stats.parsed.incrementAndGet()
+                    parseChannel.send(ParseResult.Regular(parsed, sms))
+                }
+
+                if (stats.processed.get() % PROGRESS_REPORT_FREQUENCY == 0) {
+                    reportProgress(stats)
+                }
+            }
+            parseChannel.close()
+        }
+
+        val saveJob = launch(Dispatchers.IO) {
+            for (result in parseChannel) {
+                when (result) {
+                    is ParseResult.SpecialNotification -> {
+                        result.action()
+                        stats.subscription.incrementAndGet()
+                    }
+                    is ParseResult.Regular -> {
+                        if (saveTransaction(result.parsed, result.sms, merchantMappingCache, ruleCache)) {
+                            stats.saved.incrementAndGet()
+                        }
+                    }
+                }
             }
         }
+
+        parseJob.join()
+        saveJob.join()
+
+        flushUnrecognizedBatch(unrecognizedBatch)
+        reportProgress(stats)
     }
 
-    return ProcessingResult(
-        processedCount = (endBatch - startBatch) * batchSize, // Approximate
-        parsedCount = parsedCount,
-        savedCount = savedCount,
-        subscriptionCount = subscriptionCount,
-        coroutineId = coroutineId,
-        batchNumber = startBatch
-    )
-}
+    private suspend fun processSubscription(parser: com.ritesh.parser.core.bank.BankParser, sms: SmsMessage): ParseResult? {
+        val smsDateTime = sms.timestamp.toLocalDateTime()
+        val thirtyDaysAgo = java.time.LocalDateTime.now().minusDays(30)
+        val isRecent = smsDateTime.isAfter(thirtyDaysAgo)
 
-private data class SubscriptionResult(
-    val shouldSkipTransaction: Boolean,
-    val subscriptionCount: Int
-)
-
-private suspend fun processSubscriptionNotifications(
-    parser: com.ritesh.parser.core.bank.BankParser,
-    sms: SmsMessage,
-    smsDateTime: LocalDateTime,
-    isRecentMessage: Boolean
-): SubscriptionResult {
-    return when (parser) {
-        is SBIBankParser -> {
-            if (parser.isUPIMandateNotification(sms.body)) {
-                if (!isRecentMessage) {
-                    Log.d(TAG, "Skipping old SBI UPI-Mandate from ${smsDateTime.toLocalDate()}")
-                    return SubscriptionResult(
-                        false,
-                        0
-                    ) // Continue with transaction parsing for old messages
-                }
-
-                val upiMandateInfo = parser.parseUPIMandateSubscription(sms.body)
-                if (upiMandateInfo != null) {
-                    try {
-                        val subscriptionId = subscriptionRepository.createOrUpdateFromSBIMandate(
-                            upiMandateInfo,
-                            parser.getBankName(),
-                            sms.body
-                        )
-                        Log.d(
-                            TAG,
-                            "Created/Updated SBI UPI-Mandate subscription: $subscriptionId for ${upiMandateInfo.merchant}"
-                        )
-                        return SubscriptionResult(
-                            true,
-                            1
-                        ) // Skip transaction parsing, count 1 subscription
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error saving SBI UPI-Mandate subscription: ${e.message}")
-                    }
-                }
-            }
-            SubscriptionResult(false, 0) // Continue with transaction parsing
-        }
-
-        is FederalBankParser -> {
-            // Check for E-Mandate creation notifications
-            // Note: Mandate creation messages should be processed regardless of age
-            // as they create future subscriptions
-            if (parser.isMandateCreationNotification(sms.body)) {
-                // Don't skip old mandate creation messages - they create future subscriptions
-                if (!isRecentMessage) {
-                    Log.d(
-                        TAG,
-                        "Processing older Federal Bank Mandate Creation from ${smsDateTime.toLocalDate()} - mandate creation processed regardless of age"
-                    )
-                }
-
-                val eMandateInfo = parser.parseEMandateSubscription(sms.body)
-                if (eMandateInfo != null) {
-                    try {
-                        val subscriptionId = subscriptionRepository.createOrUpdateFromFederalBankMandate(
-                            eMandateInfo,
-                            parser.getBankName(),
-                            sms.body
-                        )
-                        Log.d(
-                            TAG,
-                            "Created/Updated Federal Bank E-Mandate subscription: $subscriptionId for ${eMandateInfo.merchant}"
-                        )
-                        return SubscriptionResult(
-                            true,
-                            1
-                        ) // Skip transaction parsing, count 1 subscription
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error saving Federal Bank E-Mandate subscription: ${e.message}")
+        return when (parser) {
+            is SBIBankParser -> {
+                if (!parser.isUPIMandateNotification(sms.body)) null
+                else if (!isRecent) null
+                else parser.parseUPIMandateSubscription(sms.body)?.let { info ->
+                    ParseResult.SpecialNotification(sms) {
+                        subscriptionRepository.createOrUpdateFromSBIMandate(info, parser.getBankName(), sms.body)
                     }
                 }
             }
 
-            // Check for Future Debit notifications (payment due messages)
-            // Note: Payment due messages should be processed regardless of age if they're for future dates
-            val futureDebitInfo = parser.parseFutureDebit(sms.body)
-            if (futureDebitInfo != null) {
-                // Check if the payment due date is in the future
-                val isFuturePayment = try {
-                    val paymentDate = java.time.LocalDate.parse(
-                        futureDebitInfo.nextDeductionDate,
-                        java.time.format.DateTimeFormatter.ofPattern(futureDebitInfo.dateFormat)
-                    )
-                    paymentDate.isAfter(java.time.LocalDate.now())
-                } catch (e: Exception) {
-                    // If we can't parse the date, assume it's recent and apply normal filtering
-                    isRecentMessage
-                }
-
-                if (!isFuturePayment && !isRecentMessage) {
-                    Log.d(
-                        TAG,
-                        "Skipping old Federal Bank Future Debit from ${smsDateTime.toLocalDate()} - payment date is not in future"
-                    )
-                    return SubscriptionResult(
-                        false,
-                        0
-                    ) // Continue with transaction parsing for old messages
-                }
-
-                // Process future debit messages regardless of SMS age if payment date is future
-                if (!isRecentMessage && isFuturePayment) {
-                    Log.d(
-                        TAG,
-                        "Processing older Federal Bank Future Debit from ${smsDateTime.toLocalDate()} - payment date is future: ${futureDebitInfo.nextDeductionDate}"
-                    )
-                }
-
-                try {
-                    val subscriptionId = subscriptionRepository.createOrUpdateFromFederalBankMandate(
-                        futureDebitInfo,
-                        parser.getBankName(),
-                        sms.body
-                    )
-                    Log.d(
-                        TAG,
-                        "Created/Updated Federal Bank future debit subscription: $subscriptionId for ${futureDebitInfo.merchant}"
-                    )
-                    return SubscriptionResult(
-                        true,
-                        1
-                    ) // Skip transaction parsing, count 1 subscription
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error saving Federal Bank future debit subscription: ${e.message}")
-                }
-            }
-
-            SubscriptionResult(false, 0) // Continue with transaction parsing if no mandate found
-        }
-
-        is HDFCBankParser -> {
-            var subscriptionCount = 0
-
-            // Check for E-Mandate notifications
-            if (parser.isEMandateNotification(sms.body)) {
-                if (!isRecentMessage) {
-                    Log.d(TAG, "Skipping old HDFC E-Mandate from ${smsDateTime.toLocalDate()}")
-                    return SubscriptionResult(
-                        false,
-                        0
-                    ) // Continue with transaction parsing for old messages
-                }
-
-                val eMandateInfo = parser.parseEMandateSubscription(sms.body)
-                if (eMandateInfo != null) {
-                    try {
-                        val subscriptionId = subscriptionRepository.createOrUpdateFromEMandate(
-                            eMandateInfo,
-                            parser.getBankName(),
-                            sms.body
-                        )
-                        Log.d(
-                            TAG,
-                            "Created/Updated HDFC E-Mandate subscription: $subscriptionId for ${eMandateInfo.merchant}"
-                        )
-                        subscriptionCount++
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error saving HDFC E-Mandate subscription: ${e.message}")
+            is FederalBankParser -> {
+                if (parser.isMandateCreationNotification(sms.body)) {
+                    parser.parseEMandateSubscription(sms.body)?.let { info ->
+                        return ParseResult.SpecialNotification(sms) {
+                            subscriptionRepository.createOrUpdateFromFederalBankMandate(info, parser.getBankName(), sms.body)
+                        }
                     }
                 }
-            }
-
-            // Check for Future Debit notifications
-            if (parser.isFutureDebitNotification(sms.body)) {
-                if (!isRecentMessage) {
-                    Log.d(TAG, "Skipping old HDFC Future Debit from ${smsDateTime.toLocalDate()}")
-                    return SubscriptionResult(
-                        false,
-                        0
-                    ) // Continue with transaction parsing for old messages
-                }
-
                 val futureDebitInfo = parser.parseFutureDebit(sms.body)
                 if (futureDebitInfo != null) {
-                    try {
-                        val subscriptionId = subscriptionRepository.createOrUpdateFromEMandate(
-                            futureDebitInfo,
-                            parser.getBankName(),
-                            sms.body
-                        )
-                        Log.d(
-                            TAG,
-                            "Created/Updated HDFC future debit subscription: $subscriptionId for ${futureDebitInfo.merchant}"
-                        )
-                        subscriptionCount++
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error saving HDFC future debit subscription: ${e.message}")
+                    val isFuture = try {
+                        val d = java.time.LocalDate.parse(futureDebitInfo.nextDeductionDate, java.time.format.DateTimeFormatter.ofPattern(futureDebitInfo.dateFormat))
+                        d.isAfter(java.time.LocalDate.now())
+                    } catch (_: Exception) { false }
+                    if (!isFuture && !isRecent) null
+                    else ParseResult.SpecialNotification(sms) {
+                        subscriptionRepository.createOrUpdateFromFederalBankMandate(futureDebitInfo, parser.getBankName(), sms.body)
+                    }
+                } else null
+            }
+
+            is HDFCBankParser -> {
+                var result: ParseResult? = null
+                if (parser.isEMandateNotification(sms.body) && isRecent) {
+                    result = parser.parseEMandateSubscription(sms.body)?.let { info ->
+                        ParseResult.SpecialNotification(sms) {
+                            subscriptionRepository.createOrUpdateFromEMandate(info, parser.getBankName(), sms.body)
+                        }
                     }
                 }
-            }
-
-            // Check for Balance Update notifications
-            if (parser.isBalanceUpdateNotification(sms.body)) {
-                val balanceUpdateInfo = parser.parseBalanceUpdate(sms.body)
-                if (balanceUpdateInfo != null) {
-                    try {
-                        accountBalanceRepository.insertBalanceUpdate(
-                            bankName = balanceUpdateInfo.bankName,
-                            accountLast4 = balanceUpdateInfo.accountLast4,
-                            balance = balanceUpdateInfo.balance,
-                            timestamp = balanceUpdateInfo.asOfDate ?: smsDateTime,
-                            currency = parser.getCurrency()
-                        )
-                        Log.d(TAG, "Saved balance update for ${balanceUpdateInfo.bankName}")
-                        return SubscriptionResult(
-                            true,
-                            subscriptionCount
-                        ) // Skip transaction parsing for balance updates
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error saving balance update: ${e.message}")
+                if (result == null && parser.isFutureDebitNotification(sms.body) && isRecent) {
+                    result = parser.parseFutureDebit(sms.body)?.let { info ->
+                        ParseResult.SpecialNotification(sms) {
+                            subscriptionRepository.createOrUpdateFromEMandate(info, parser.getBankName(), sms.body)
+                        }
                     }
                 }
-            }
-
-            if (subscriptionCount > 0) {
-                SubscriptionResult(
-                    true,
-                    subscriptionCount
-                ) // Skip transaction parsing for subscriptions
-            } else {
-                SubscriptionResult(false, 0) // Continue with transaction parsing
-            }
-        }
-
-        is IndianBankParser -> {
-            if (parser.isMandateNotification(sms.body)) {
-                if (!isRecentMessage) {
-                    Log.d(TAG, "Skipping old Indian Bank Mandate from ${smsDateTime.toLocalDate()}")
-                    return SubscriptionResult(
-                        false,
-                        0
-                    ) // Continue with transaction parsing for old messages
-                }
-
-                val mandateInfo = parser.parseMandateSubscription(sms.body)
-                if (mandateInfo != null) {
-                    try {
-                        val subscriptionId =
-                            subscriptionRepository.createOrUpdateFromIndianBankMandate(
-                                mandateInfo,
-                                parser.getBankName(),
-                                sms.body
+                if (result == null && parser.isBalanceUpdateNotification(sms.body)) {
+                    result = parser.parseBalanceUpdate(sms.body)?.let { info ->
+                        ParseResult.SpecialNotification(sms) {
+                            accountBalanceRepository.insertBalanceUpdate(
+                                bankName = info.bankName,
+                                accountLast4 = info.accountLast4 ?: "XXXX",
+                                balance = info.balance,
+                                timestamp = info.asOfDate ?: smsDateTime,
+                                currency = parser.getCurrency()
                             )
-                        Log.d(
-                            TAG,
-                            "Created/Updated Indian Bank subscription: $subscriptionId for ${mandateInfo.merchant}"
-                        )
-                        return SubscriptionResult(
-                            true,
-                            1
-                        ) // Skip transaction parsing, count 1 subscription
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error saving Indian Bank subscription: ${e.message}")
+                        }
+                    }
+                }
+                result
+            }
+
+            is IndianBankParser -> {
+                if (!parser.isMandateNotification(sms.body)) null
+                else if (!isRecent) null
+                else parser.parseMandateSubscription(sms.body)?.let { info ->
+                    ParseResult.SpecialNotification(sms) {
+                        subscriptionRepository.createOrUpdateFromIndianBankMandate(info, parser.getBankName(), sms.body)
                     }
                 }
             }
-            SubscriptionResult(false, 0) // Continue with transaction parsing
-        }
 
-        is IndusIndBankParser -> {
-            // Balance-only updates for IndusInd (hook like HDFC)
-            if (parser.isBalanceUpdateNotification(sms.body)) {
-                val balanceUpdateInfo = parser.parseBalanceUpdate(sms.body)
-                if (balanceUpdateInfo != null) {
-                    try {
+            is IndusIndBankParser -> {
+                if (!parser.isBalanceUpdateNotification(sms.body)) null
+                else parser.parseBalanceUpdate(sms.body)?.let { info ->
+                    ParseResult.SpecialNotification(sms) {
                         accountBalanceRepository.insertBalanceUpdate(
-                            bankName = balanceUpdateInfo.bankName,
-                            accountLast4 = balanceUpdateInfo.accountLast4,
-                            balance = balanceUpdateInfo.balance,
-                            timestamp = balanceUpdateInfo.asOfDate ?: smsDateTime,
+                            bankName = info.bankName,
+                            accountLast4 = info.accountLast4 ?: "XXXX",
+                            balance = info.balance,
+                            timestamp = info.asOfDate ?: smsDateTime,
                             currency = parser.getCurrency()
                         )
-                        Log.d(TAG, "Saved balance update for ${balanceUpdateInfo.bankName}")
-                        return SubscriptionResult(true, 0) // Skip transaction parsing for balance updates
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error saving IndusInd balance update: ${e.message}")
                     }
                 }
             }
-            SubscriptionResult(false, 0)
+
+            else -> null
         }
-
-        else -> SubscriptionResult(false, 0) // Continue with transaction parsing for other banks
     }
-}
 
-private suspend fun saveParsedTransaction(
-    parsedTransaction: ParsedTransaction,
-    sms: SmsMessage
-): Boolean {
-    return try {
-        // Convert to entity and save
-        val entity = parsedTransaction.toEntity()
+    private suspend fun saveTransaction(
+        parsed: ParsedTransaction,
+        sms: SmsMessage,
+        merchantMappingCache: Map<String, String>,
+        ruleCache: Map<com.ritesh.cashiro.data.database.entity.TransactionType, List<com.ritesh.cashiro.data.database.entity.RuleEntity>>
+    ): Boolean {
+        return try {
+            val entity = parsed.toEntity()
+            if (transactionRepository.getTransactionByHash(entity.transactionHash) != null) return false
 
-        // Check if this transaction was previously deleted by the user
-        val existingTransaction = transactionRepository.getTransactionByHash(entity.transactionHash)
-        if (existingTransaction != null) {
-            if (existingTransaction.isDeleted) {
-                Log.d(
-                    TAG,
-                    "Skipping previously deleted transaction with hash: ${entity.transactionHash}"
-                )
+            val mapped = merchantMappingCache[entity.merchantName]?.let { entity.copy(category = it) } ?: entity
+            val activeRules = ruleCache[mapped.transactionType] ?: emptyList()
+            if (ruleEngine.shouldBlockTransaction(mapped, sms.body, activeRules) != null) {
                 return false
             }
-            // Transaction already exists and not deleted - normal deduplication
-            Log.d(TAG, "Transaction already exists: ${entity.transactionHash}")
-            return false
+
+            val (withRules, ruleApps) = ruleEngine.evaluateRules(mapped, sms.body, activeRules)
+            val matchedSub = subscriptionRepository.matchTransactionToSubscription(withRules.merchantName, withRules.amount)
+            val finalEntity = if (matchedSub != null) {
+                subscriptionRepository.updateNextPaymentDateAfterCharge(matchedSub.id, withRules.dateTime.toLocalDate())
+                withRules.copy(isRecurring = true)
+            } else withRules
+
+            val rowId = transactionRepository.insertTransaction(finalEntity)
+            if (rowId == -1L) return false
+
+            if (ruleApps.isNotEmpty()) ruleRepository.saveRuleApplications(ruleApps)
+            processBalanceUpdate(parsed, finalEntity, rowId)
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Error saving transaction: ${e.message}")
+            false
         }
-
-        // Check for custom merchant mapping
-        val customCategory = merchantMappingRepository.getCategoryForMerchant(entity.merchantName)
-        val entityWithMapping = if (customCategory != null) {
-            Log.d(TAG, "Found custom category mapping: ${entity.merchantName} -> $customCategory")
-            entity.copy(category = customCategory)
-        } else {
-            entity
-        }
-
-        // Apply rule engine to the transaction
-        val activeRules = ruleRepository.getActiveRulesByType(entityWithMapping.transactionType)
-
-        // Check if this transaction should be blocked
-        val blockingRule = ruleEngine.shouldBlockTransaction(
-            entityWithMapping,
-            sms.body,
-            activeRules
-        )
-
-        if (blockingRule != null) {
-            Log.d(TAG, "Transaction blocked by rule: ${blockingRule.name}")
-            return false  // Don't save the transaction
-        }
-
-        val (entityWithRules, ruleApplications) = ruleEngine.evaluateRules(
-            entityWithMapping,
-            sms.body,
-            activeRules
-        )
-
-        if (ruleApplications.isNotEmpty()) {
-            Log.d(TAG, "Applied ${ruleApplications.size} rules to transaction")
-            ruleApplications.forEach { app ->
-                Log.d(TAG, "Applied rule: ${app.ruleName}")
-            }
-        }
-
-        // Check if this transaction matches an active subscription
-        val matchedSubscription = subscriptionRepository.matchTransactionToSubscription(
-            entityWithRules.merchantName,
-            entityWithRules.amount
-        )
-
-        val finalEntity = if (matchedSubscription != null) {
-            Log.d(
-                TAG,
-                "Transaction matched to active subscription: ${matchedSubscription.merchantName}"
-            )
-            subscriptionRepository.updateNextPaymentDateAfterCharge(
-                matchedSubscription.id,
-                entityWithRules.dateTime.toLocalDate()
-            )
-            entityWithRules.copy(isRecurring = true)
-        } else {
-            entityWithRules
-        }
-
-        val rowId = transactionRepository.insertTransaction(finalEntity)
-        if (rowId != -1L) {
-            Log.d(
-                TAG,
-                "Saved new transaction with ID: $rowId${if (finalEntity.isRecurring) " (Recurring)" else ""}"
-            )
-
-            // Save rule applications if any rules were applied
-            if (ruleApplications.isNotEmpty()) {
-                val applicationsWithId = ruleApplications.map { 
-                    it.copy(transactionId = rowId.toString())
-                }
-                ruleRepository.saveRuleApplications(applicationsWithId)
-                Log.d(
-                    TAG,
-                    "Saved ${ruleApplications.size} rule applications for transaction: $rowId"
-                )
-            }
-
-            // Process balance updates
-            processBalanceUpdate(parsedTransaction, finalEntity, rowId)
-            return true
-        } else {
-            Log.d(
-                TAG,
-                "Transaction already exists (duplicate), skipping both transaction and balance update: ${entity.transactionHash}"
-            )
-        }
-        false
-    } catch (e: Exception) {
-        Log.e(TAG, "Error saving transaction: ${e.message}")
-        false
     }
-}
 
-private suspend fun processBalanceUpdate(
-    parsedTransaction: ParsedTransaction,
-    entity: com.ritesh.cashiro.data.database.entity.TransactionEntity,
-    rowId: Long
-) {
-    if (parsedTransaction.accountLast4 != null) {
-        // Determine if this transaction is from a card based on the message pattern
-        val isFromCard = parsedTransaction.isFromCard
-
-        Log.d(
-            TAG, """
-                Processing transaction:
-                - Bank: ${parsedTransaction.bankName}
-                - Number: **${parsedTransaction.accountLast4}
-                - Is From Card: $isFromCard
-                - Transaction Type: ${parsedTransaction.type}
-                - SMS Body (first 200 chars): ${parsedTransaction.smsBody.take(200)}
-            """.trimIndent()
-        )
-
-        val targetAccountLast4 = if (isFromCard) {
-            // This is a card transaction
-            Log.d(TAG, "Transaction identified as CARD transaction")
-
-            var card = parsedTransaction.accountLast4?.let {
-                cardRepository.getCard(parsedTransaction.bankName, it)
-            }
-
-            if (card == null) {
-                // First time seeing this card - create it
-                // Determine if it's a credit card based on transaction type
-                val isCredit = (parsedTransaction.type.toEntityType() == TransactionType.CREDIT)
-                Log.d(TAG, "Creating new card for ${parsedTransaction.bankName}")
-
-                card = parsedTransaction.accountLast4?.let { accountLast4 ->
-                    cardRepository.findOrCreateCard(
-                        cardLast4 = accountLast4,
-                        bankName = parsedTransaction.bankName,
-                        isCredit = isCredit
-                    )
+    private suspend fun processBalanceUpdate(parsed: ParsedTransaction, entity: com.ritesh.cashiro.data.database.entity.TransactionEntity, rowId: Long) {
+        val accountLast4 = parsed.accountLast4 ?: return
+        val card = if (parsed.isFromCard) {
+            cardRepository.getCard(parsed.bankName, accountLast4)
+                ?: cardRepository.findOrCreateCard(accountLast4, parsed.bankName, parsed.type.toEntityType() == TransactionType.CREDIT)
+                ?.also { c ->
+                    cardRepository.getCard(parsed.bankName, accountLast4)
                 }
-
-                // CRITICAL: Refetch the card to get the actual state (might have been created before)
-                card = parsedTransaction.accountLast4?.let {
-                    cardRepository.getCard(parsedTransaction.bankName, it)
-                }!!
-                Log.d(TAG, "Card created/found successfully")
-            } else {
-                Log.d(TAG, "Found existing card")
-            }
-
-            // Always update card's balance and source (for debugging)
-            Log.d(TAG, "Updating card balance")
-            cardRepository.updateCardBalance(
-                cardId = card.id,
-                balance = parsedTransaction.balance,  // Can be null
-                source = parsedTransaction.smsBody.take(200),  // Always save source
-                date = LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(parsedTransaction.timestamp),
-                    ZoneId.systemDefault()
-                )
-            )
-
-            // For cards, check if we should create balance entry
-            val result = when {
-                card.cardType == com.ritesh.cashiro.data.database.entity.CardType.CREDIT -> {
-                    // Credit cards get balance entries
-                    Log.d(TAG, "CREDIT card - will create balance entry")
-                    parsedTransaction.accountLast4
+                ?.also { c ->
+                    cardRepository.updateCardBalance(c.id, parsed.balance, parsed.smsBody.take(200), parsed.timestamp.toLocalDateTime())
                 }
+        } else null
 
-                card.cardType == com.ritesh.cashiro.data.database.entity.CardType.DEBIT && card.accountLast4 != null -> {
-                    // Linked debit card - use the linked account for balance
-                    Log.d(
-                        TAG,
-                        "DEBIT card linked to account **${card.accountLast4} - will update linked account balance"
-                    )
-                    card.accountLast4
-                }
-
-                else -> {
-                    // Unlinked debit card - no balance entry
-                    Log.d(TAG, "DEBIT card NOT linked - NO balance entry will be created")
-                    null
-                }
-            }
-            result
-        } else {
-            // This is a direct account transaction - always create balance entry
-            Log.d(TAG, "Transaction identified as ACCOUNT transaction - will create balance entry")
-            parsedTransaction.accountLast4
+        val targetAccount = when {
+            card == null -> accountLast4
+            card.cardType == com.ritesh.cashiro.data.database.entity.CardType.CREDIT -> accountLast4
+            card.cardType == com.ritesh.cashiro.data.database.entity.CardType.DEBIT && card.accountLast4 != null -> card.accountLast4
+            else -> return
         }
 
-        // Create balance entry if we have a target account
-        if (targetAccountLast4 != null) {
-            val isCreditCard = (parsedTransaction.type.toEntityType() == TransactionType.CREDIT) ||
-                    parsedTransaction.accountLast4?.let {
-                        cardRepository.getCard(parsedTransaction.bankName, it)?.cardType
-                    } == com.ritesh.cashiro.data.database.entity.CardType.CREDIT
+        val isCreditCard = card?.cardType == com.ritesh.cashiro.data.database.entity.CardType.CREDIT || parsed.type.toEntityType() == TransactionType.CREDIT
+        val existing = accountBalanceRepository.getLatestBalance(parsed.bankName, targetAccount)
 
-            val existingAccount = accountBalanceRepository.getLatestBalance(
-                parsedTransaction.bankName,
-                targetAccountLast4
-            )
-
-            val newBalance = when {
-                isCreditCard -> {
-                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
-                    currentBalance + parsedTransaction.amount
-                }
-
-                existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                    val currentBalance = existingAccount.balance ?: BigDecimal.ZERO
-                    (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
-                }
-
-                parsedTransaction.balance != null -> {
-                    parsedTransaction.balance!!
-                }
-
-                else -> {
-                    // SMS doesn't have explicit balance - calculate based on transaction type
-                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
-                    when (parsedTransaction.type.toEntityType()) {
-                        TransactionType.INCOME -> {
-                            // Money coming in - add to balance
-                            currentBalance + parsedTransaction.amount
-                        }
-                        TransactionType.EXPENSE, TransactionType.INVESTMENT -> {
-                            // Money going out - subtract from balance
-                            (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
-                        }
-                        TransactionType.CREDIT, TransactionType.TRANSFER -> {
-                            // Keep existing balance for transfers (complex logic needed)
-                            // Credit should be handled above, this is fallback
-                            currentBalance
-                        }
-                    }
+        val newBalance = when {
+            parsed.balance != null -> parsed.balance!!
+            isCreditCard -> (existing?.balance ?: BigDecimal.ZERO) + parsed.amount
+            existing?.isCreditCard == true && parsed.type.toEntityType() == TransactionType.INCOME ->
+                (existing.balance - parsed.amount).max(BigDecimal.ZERO)
+            else -> {
+                val cur = existing?.balance ?: BigDecimal.ZERO
+                when (parsed.type.toEntityType()) {
+                    TransactionType.INCOME -> cur + parsed.amount
+                    TransactionType.EXPENSE, TransactionType.INVESTMENT -> (cur - parsed.amount).max(BigDecimal.ZERO)
+                    else -> cur
                 }
             }
+        }
 
-            val balanceSource = when {
-                isCreditCard -> "Calculated (Credit Card)"
-                existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> "Calculated (CC Payment)"
-                parsedTransaction.balance != null -> "From SMS"
-                else -> "Calculated (${parsedTransaction.type.toEntityType()})"
-            }
+        val balanceEntity = AccountBalanceEntity(
+            bankName = parsed.bankName,
+            accountLast4 = targetAccount,
+            balance = newBalance,
+            timestamp = entity.dateTime,
+            transactionId = rowId,
+            creditLimit = existing?.creditLimit,
+            isCreditCard = isCreditCard || (existing?.isCreditCard ?: false),
+            smsSource = parsed.smsBody.take(500),
+            sourceType = "TRANSACTION",
+            currency = parsed.currency
+        )
+        accountBalanceRepository.insertBalance(balanceEntity)
+        Log.i(TAG, "Balance saved for ${parsed.bankName} **$targetAccount: ${CurrencyFormatter.formatCurrency(newBalance, parsed.currency)}")
+    }
 
-            Log.d(
-                TAG, """
-                    Saving account balance:
-                    - SMS Timestamp: ${parsedTransaction.timestamp} (${java.time.Instant.ofEpochMilli(parsedTransaction.timestamp)})
-                    - Bank: ${parsedTransaction.bankName}
-                    - Original: **${parsedTransaction.accountLast4}
-                    - Target Account: **$targetAccountLast4
-                    - Is Card Transaction: ${parsedTransaction.isFromCard}
-                    - Is Credit Card: $isCreditCard
-                    - Transaction Type: ${parsedTransaction.type.toEntityType()}
-                    - Transaction Amount: ${parsedTransaction.amount}
-                    - Previous Balance: ${existingAccount?.balance}
-                    - New Balance: $newBalance
-                    - Balance Source: $balanceSource
-                    - Available Limit (from SMS): ${parsedTransaction.creditLimit}
-                """.trimIndent()
-            )
-
-            // Save balance if:
-            val shouldSaveBalance = when {
-                parsedTransaction.balance != null -> true  // Always save if SMS had explicit balance
-                parsedTransaction.creditLimit != null -> true  // Save if credit limit info
-                newBalance != BigDecimal.ZERO -> true  // Save non-zero balances
-                existingAccount != null -> true  // Save to update existing account or create new one
-                else -> true  // Create new account even with 0 balance (first time)
-            }
-
-            if (shouldSaveBalance) {
-                // Create the balance entity using the target account
-                val balanceEntity = AccountBalanceEntity(
-                    bankName = parsedTransaction.bankName,
-                    accountLast4 = targetAccountLast4,
-                    balance = newBalance,
-                    timestamp = entity.dateTime,
-                    transactionId = if (rowId != -1L) rowId else null,
-                    creditLimit = existingAccount?.creditLimit, // Keep existing credit limit
-                    isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
-                    smsSource = parsedTransaction.smsBody.take(500),  // Store SMS snippet
-                    sourceType = "TRANSACTION",
-                    currency = parsedTransaction.currency
-                )
-
-                accountBalanceRepository.insertBalance(balanceEntity)
-
-                val logMsg = if (parsedTransaction.creditLimit != null) {
-                    "Saved balance/credit limit (${
-                        CurrencyFormatter.formatCurrency(
-                            parsedTransaction.creditLimit!!
+    private suspend fun flushUnrecognizedBatch(batch: ArrayList<SmsMessage>) {
+        for (sms in batch) {
+            try {
+                if (!unrecognizedSmsRepository.exists(sms.sender, sms.body)) {
+                    unrecognizedSmsRepository.insert(
+                        com.ritesh.cashiro.data.database.entity.UnrecognizedSmsEntity(
+                            sender = sms.sender,
+                            smsBody = sms.body,
+                            receivedAt = sms.timestamp.toLocalDateTime()
                         )
-                    }) for ${parsedTransaction.bankName} **$targetAccountLast4"
-                } else {
-                    "Saved balance update for ${parsedTransaction.bankName} **$targetAccountLast4"
+                    )
                 }
-                Log.d(TAG, logMsg)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error storing unrecognized SMS: ${e.message}")
+            }
+        }
+        batch.clear()
+    }
+
+    private suspend fun cleanUpAndFinalize(stats: ProcessingStats) {
+        try { unrecognizedSmsRepository.cleanupOldEntries() } catch (e: Exception) { Log.e(TAG, "Cleanup error: ${e.message}") }
+        if (stats.saved.get() > 0) {
+            try { llmRepository.updateSystemPrompt() } catch (e: Exception) { Log.e(TAG, "Prompt update error: ${e.message}") }
+        }
+    }
+
+    private suspend fun reportProgress(stats: ProcessingStats) {
+        try {
+            setProgress(workDataOf(
+                PROGRESS_TOTAL to stats.total,
+                PROGRESS_PROCESSED to stats.processed.get(),
+                PROGRESS_PARSED to stats.parsed.get(),
+                PROGRESS_SAVED to stats.saved.get(),
+                PROGRESS_BLOCKED to stats.blocked.get(),
+                PROGRESS_TIME_ELAPSED to stats.elapsedMs(),
+                PROGRESS_ESTIMATED_TIME_REMAINING to (stats.etaSec() * 1000L),
+                PROGRESS_ETA_SECONDS to stats.etaSec(),
+                PROGRESS_MSG_PER_SEC to stats.msgPerSec(),
+                PROGRESS_CURRENT_BATCH to stats.processed.get(),
+                PROGRESS_TOTAL_BATCHES to stats.total
+            ))
+        } catch (_: Exception) {}
+    }
+
+    private suspend fun readSmsMessages(forceResync: Boolean = false): List<SmsMessage> {
+        val messages = mutableListOf<SmsMessage>()
+        try {
+            val lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first() ?: 0L
+            val scanMonths = userPreferencesRepository.getSmsScanMonths()
+            val scanAllTime = userPreferencesRepository.getSmsScanAllTime()
+            val lastScanPeriod = userPreferencesRepository.getLastScanPeriod().first() ?: 0
+            val now = System.currentTimeMillis()
+
+            val scanAllTimeToggled = scanAllTime && lastScanPeriod != -1
+            val scanAllTimeToggledOff = !scanAllTime && lastScanPeriod == -1
+            val needsFullScan = forceResync || lastScanTimestamp == 0L || (lastScanPeriod >= 0 && scanMonths > lastScanPeriod) || scanAllTimeToggled || scanAllTimeToggledOff
+
+            val scanStartTime = if (needsFullScan) {
+                java.util.Calendar.getInstance().apply {
+                    if (scanAllTime) add(java.util.Calendar.YEAR, -10)
+                    else add(java.util.Calendar.MONTH, -scanMonths)
+                    set(java.util.Calendar.HOUR_OF_DAY, 0); set(java.util.Calendar.MINUTE, 0)
+                    set(java.util.Calendar.SECOND, 0); set(java.util.Calendar.MILLISECOND, 0)
+                }.timeInMillis
             } else {
-                Log.d(
-                    TAG,
-                    "Skipped saving balance: ${parsedTransaction.bankName} **$targetAccountLast4"
-                )
+                val threeDaysAgo = now - 3 * 24 * 60 * 60 * 1000L
+                val periodLimit = java.util.Calendar.getInstance().apply { add(java.util.Calendar.MONTH, -scanMonths) }.timeInMillis
+                maxOf(minOf(lastScanTimestamp, threeDaysAgo), periodLimit)
             }
-        } else {
-            Log.d(
-                TAG,
-                "No balance entry created for unlinked debit card: ${parsedTransaction.bankName} **${parsedTransaction.accountLast4}"
-            )
-        }
-    }
-}
 
-private suspend fun processUnrecognizedSms(sms: SmsMessage) {
-    val upperSender = sms.sender.uppercase()
-    if (upperSender.endsWith("-T") || upperSender.endsWith("-S")) {
-        try {
-            if (!SmsFilter.isTransactionMessage(sms.body)) {
-                Log.d(TAG, "Skipping non-transaction unrecognized SMS from: ${sms.sender}")
-                return
-            }
-            val alreadyExists = unrecognizedSmsRepository.exists(sms.sender, sms.body)
-
-            if (!alreadyExists) {
-                val unrecognizedSms = UnrecognizedSmsEntity(
-                    sender = sms.sender,
-                    smsBody = sms.body,
-                    receivedAt = LocalDateTime.ofInstant(
-                        Instant.ofEpochMilli(sms.timestamp),
-                        ZoneId.systemDefault()
-                    )
-                )
-                unrecognizedSmsRepository.insert(unrecognizedSms)
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error storing unrecognized SMS: ${e.message}")
-        }
-    }
-}
-
-private suspend fun readSmsMessages(forceResync: Boolean = false): List<SmsMessage> {
-    val messages = mutableListOf<SmsMessage>()
-
-    try {
-        // Get scan parameters
-        val lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first() ?: 0L
-        val scanMonths = userPreferencesRepository.getSmsScanMonths()
-        val scanAllTime = userPreferencesRepository.getSmsScanAllTime()
-        val lastScanPeriod = userPreferencesRepository.getLastScanPeriod().first() ?: 0
-        val now = System.currentTimeMillis()
-
-        // Determine if we need a full scan
-        // Force resync always triggers a full scan from scratch
-        val needsFullScan = forceResync || lastScanTimestamp == 0L || scanAllTime || scanMonths > lastScanPeriod
-
-        if (forceResync) {
-            Log.d(TAG, "Force resync requested - performing full scan and reprocessing all messages")
-        }
-
-        // Calculate scan start time
-        val scanStartTime = if (needsFullScan) {
-            val calendar = java.util.Calendar.getInstance().apply {
-                if (scanAllTime) {
-                    // Scan all time - go back 10 years (effectively all SMS)
-                    add(java.util.Calendar.YEAR, -10)
-                    Log.d(TAG, "Performing full SMS scan for all time")
-                } else {
-                    add(java.util.Calendar.MONTH, -scanMonths)
-                    Log.d(TAG, "Performing full SMS scan for last $scanMonths months")
-                }
-                set(java.util.Calendar.HOUR_OF_DAY, 0)
-                set(java.util.Calendar.MINUTE, 0)
-                set(java.util.Calendar.SECOND, 0)
-                set(java.util.Calendar.MILLISECOND, 0)
-            }
-            calendar.timeInMillis
-        } else {
-            val threeDaysAgo = now - (3 * 24 * 60 * 60 * 1000L)
-            val periodLimit = java.util.Calendar.getInstance().apply {
-                add(java.util.Calendar.MONTH, -scanMonths)
-            }.timeInMillis
-
-            val incrementalStart = maxOf(
-                minOf(lastScanTimestamp, threeDaysAgo),
-                periodLimit
-            )
-
-            val daysSinceLastScan = (now - lastScanTimestamp) / (24 * 60 * 60 * 1000L)
-            Log.d(TAG, "Performing incremental SMS scan (last scan: $daysSinceLastScan days ago)")
-            incrementalStart
-        }
-
-        // Query SMS inbox
-        val cursor = applicationContext.contentResolver.query(
-            Telephony.Sms.CONTENT_URI,
-            SMS_PROJECTION,
-            "${Telephony.Sms.TYPE} = ? AND ${Telephony.Sms.DATE} >= ?",
-            arrayOf(Telephony.Sms.MESSAGE_TYPE_INBOX.toString(), scanStartTime.toString()),
-            "${Telephony.Sms.DATE} ASC"  // Process oldest first (chronological order)
-        )
-
-        cursor?.use {
-            val idIndex = it.getColumnIndexOrThrow(Telephony.Sms._ID)
-            val addressIndex = it.getColumnIndexOrThrow(Telephony.Sms.ADDRESS)
-            val dateIndex = it.getColumnIndexOrThrow(Telephony.Sms.DATE)
-            val bodyIndex = it.getColumnIndexOrThrow(Telephony.Sms.BODY)
-            val typeIndex = it.getColumnIndexOrThrow(Telephony.Sms.TYPE)
-
-            while (it.moveToNext()) {
-                val message = SmsMessage(
-                    id = it.getLong(idIndex),
-                    sender = it.getString(addressIndex) ?: "",
-                    timestamp = it.getLong(dateIndex),
-                    body = it.getString(bodyIndex) ?: "",
-                    type = it.getInt(typeIndex)
-                )
-                messages.add(message)
-            }
-        }
-
-        // Log SMS processing order for verification
-        if (messages.isNotEmpty()) {
-            val firstMsg = messages.first()
-            val lastMsg = messages.last()
-            Log.d(TAG, """
-                Loaded ${messages.size} SMS messages
-                - First (oldest): ${java.time.Instant.ofEpochMilli(firstMsg.timestamp)}
-                - Last (newest): ${java.time.Instant.ofEpochMilli(lastMsg.timestamp)}
-                - Processing order: Chronological (oldest → newest)
-            """.trimIndent())
-        }
-
-        // Update scan tracking
-        userPreferencesRepository.setLastScanTimestamp(System.currentTimeMillis())
-        if (needsFullScan) {
-            userPreferencesRepository.setLastScanPeriod(scanMonths)
-        }
-
-        Log.d(TAG, "SMS scan completed. Found ${messages.size} messages")
-
-        // Try to read RCS messages from MMS provider
-        try {
-            // MMS/RCS uses seconds since epoch, not milliseconds
-            val scanStartTimeSeconds = scanStartTime / 1000
-
-            val mmsCursor = applicationContext.contentResolver.query(
-                Uri.parse("content://mms"),
-                arrayOf("_id", "thread_id", "date", "tr_id", "m_id"),
-                "date >= ?",
-                arrayOf(scanStartTimeSeconds.toString()),
-                "date DESC"
-            )
-
-            mmsCursor?.use { cursor ->
-                while (cursor.moveToNext()) {
-                    val messageId = cursor.getLong(cursor.getColumnIndexOrThrow("_id"))
-                    val date = cursor.getLong(cursor.getColumnIndexOrThrow("date"))
-                    val trIdIndex = cursor.getColumnIndex("tr_id")
-                    val trId = if (trIdIndex >= 0) cursor.getString(trIdIndex) ?: "" else ""
-
-                    // Check if this is an RCS message (has proto: in tr_id)
-                    if (trId.startsWith("proto:")) {
-                        // Extract sender from tr_id (it's base64 encoded protobuf)
-                        val sender = extractRcsSender(trId)
-
-                        // Get message text from parts
-                        var messageText = getRcsMessageText(messageId)
-
-                        // If it's JSON (RCS Rich Card), extract the actual text
-                        if (messageText != null && messageText.trim().startsWith("{")) {
-                            messageText = extractTextFromRcsJson(messageText)
-                        }
-
-                        // Convert to SmsMessage format for processing
-                        if (messageText != null && sender != null) {
-                            val senderUpper = sender.uppercase()
-                            // Process RCS messages from known financial senders (PNB, Department of Post)
-                            if (senderUpper.contains("PUNJAB NATIONAL BANK") ||
-                                senderUpper.contains("DEPARTMENT OF POST") ||
-                                senderUpper.contains("DOPBNK")) {
-                                Log.d(TAG, "RCS message from recognized financial sender: $sender")
-                                val rcsMessage = SmsMessage(
-                                    id = messageId,
-                                    sender = sender,
-                                    timestamp = date * 1000, // MMS uses seconds, SMS uses milliseconds
-                                    body = messageText,
-                                    type = Telephony.Sms.MESSAGE_TYPE_INBOX
-                                )
-                                messages.add(rcsMessage)
-                            } else {
-                                Log.d(TAG, "Skipping RCS message from non-financial sender: $sender")
-                            }
-                        }
-                    }
+            applicationContext.contentResolver.query(
+                Telephony.Sms.CONTENT_URI, SMS_PROJECTION,
+                "${Telephony.Sms.TYPE} = ? AND ${Telephony.Sms.DATE} >= ?",
+                arrayOf(Telephony.Sms.MESSAGE_TYPE_INBOX.toString(), scanStartTime.toString()),
+                "${Telephony.Sms.DATE} ASC"
+            )?.use { c ->
+                val idIdx = c.getColumnIndexOrThrow(Telephony.Sms._ID)
+                val addressIdx = c.getColumnIndexOrThrow(Telephony.Sms.ADDRESS)
+                val dateIdx = c.getColumnIndexOrThrow(Telephony.Sms.DATE)
+                val bodyIdx = c.getColumnIndexOrThrow(Telephony.Sms.BODY)
+                val typeIdx = c.getColumnIndexOrThrow(Telephony.Sms.TYPE)
+                while (c.moveToNext()) {
+                    messages.add(SmsMessage(c.getLong(idIdx), c.getString(addressIdx) ?: "", c.getLong(dateIdx), c.getString(bodyIdx) ?: "", c.getInt(typeIdx)))
                 }
             }
+
+            userPreferencesRepository.setLastScanTimestamp(now)
+            if (needsFullScan) userPreferencesRepository.setLastScanPeriod(if (scanAllTime) -1 else scanMonths)
+
+            try { messages.addAll(readRcsMessages(scanStartTime / 1000)) } catch (e: Exception) { Log.e(TAG, "RCS read error: ${e.message}") }
         } catch (e: Exception) {
-            Log.e(TAG, "Error reading RCS messages: ${e.message}")
+            Log.e(TAG, "Error reading SMS", e)
         }
-    } catch (e: Exception) {
-        Log.e(TAG, "Error querying SMS content provider", e)
+        Log.i(TAG, "Loaded ${messages.size} messages (SMS + RCS)")
+        return messages
     }
 
-    return messages
-}
-
-/**
- * Extracts sender name from RCS tr_id field
- * The tr_id contains base64 encoded protobuf data with sender info
- */
-private fun extractRcsSender(trId: String): String? {
-    return try {
-        // Remove "proto:" prefix and decode base64
-        val base64Data = trId.removePrefix("proto:")
-        val decodedBytes = android.util.Base64.decode(base64Data, android.util.Base64.DEFAULT)
-        val decodedString = String(decodedBytes)
-
-        // Look for sender patterns in the decoded data
-        // Pattern 1: Agent ID like "ask_apollo_9xdchzx9_agent@rbm.goog"
-        val agentPattern = Regex("""([a-z_]+)_[a-z0-9]+_agent@rbm\.goog""")
-        agentPattern.find(decodedString)?.let { match ->
-            // Convert agent ID to readable name (e.g., "ask_apollo" -> "Ask Apollo")
-            return match.groupValues[1].split("_").joinToString(" ") {
-                it.replaceFirstChar { char -> char.uppercase() }
+    private fun readRcsMessages(scanStartSeconds: Long): List<SmsMessage> {
+        val result = mutableListOf<SmsMessage>()
+        applicationContext.contentResolver.query(
+            "content://mms".toUri(), arrayOf("_id", "thread_id", "date", "tr_id", "m_id"),
+            "date >= ?", arrayOf(scanStartSeconds.toString()), "date DESC"
+        )?.use { c ->
+            while (c.moveToNext()) {
+                val messageId = c.getLong(c.getColumnIndexOrThrow("_id"))
+                val date = c.getLong(c.getColumnIndexOrThrow("date"))
+                val trId = c.getColumnIndex("tr_id").takeIf { it >= 0 }?.let { c.getString(it) } ?: continue
+                if (!trId.startsWith("proto:")) continue
+                val sender = extractRcsSender(trId) ?: continue
+                if (!sender.uppercase().contains("PUNJAB NATIONAL BANK")) continue
+                var text = getRcsMessageText(messageId) ?: continue
+                if (text.trim().startsWith("{")) text = extractTextFromRcsJson(text) ?: continue
+                result.add(SmsMessage(messageId, sender, date * 1000, text, Telephony.Sms.MESSAGE_TYPE_INBOX))
             }
         }
-
-        // Pattern 2: Look for actual sender name in the data
-        // RCS messages often have the business name directly in the protobuf
-        val namePattern = Regex("""[\x12\x1a][\x00-\x20]([A-Za-z][A-Za-z\s]+)""")
-        namePattern.find(decodedString)?.let { match ->
-            val name = match.groupValues[1].trim()
-            if (name.length > 3 && name.length < 50) {
-                return name
-            }
-        }
-
-        // If no pattern matches, return null
-        null
-    } catch (e: Exception) {
-        Log.e(TAG, "Error extracting RCS sender: ${e.message}")
-        null
+        return result
     }
-}
 
-/**
- * Gets the text content of an RCS/MMS message from its parts
- */
-private fun getRcsMessageText(messageId: Long): String? {
-    return try {
-        // First, let's see what parts exist for this message
-        val partsCursor = applicationContext.contentResolver.query(
-            Uri.parse("content://mms/part"),
-            null, // Get all columns to debug
-            "mid = ?",
-            arrayOf(messageId.toString()),
+    private fun extractRcsSender(trId: String): String? = try {
+        val decoded = String(android.util.Base64.decode(trId.removePrefix("proto:"), android.util.Base64.DEFAULT))
+        Regex("""([a-z_]+)_[a-z0-9]+_agent@rbm\.goog""").find(decoded)?.let { m ->
+            return m.groupValues[1].split(" ").joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
+        }
+        Regex("""[\x12\x1a][\x00-\x20]([A-Za-z][A-Za-z\s]+)""").find(decoded)?.let { m ->
+            val name = m.groupValues[1].trim()
+            if (name.length in 4..49) return name
+        }
+        null
+    } catch (_: Exception) { null }
+
+    private fun getRcsMessageText(messageId: Long): String? = try {
+        applicationContext.contentResolver.query("content://mms/part".toUri(), null, "mid = ?", arrayOf(messageId.toString()), null)?.use { c ->
+            while (c.moveToNext()) {
+                val ct = c.getColumnIndex("ct").takeIf { it >= 0 }?.let { c.getString(it) } ?: continue
+                if (!ct.startsWith("text/") && ct != "application/smil") continue
+                c.getColumnIndex("text").takeIf { it >= 0 }?.let { idx ->
+                    c.getString(idx)?.takeIf { it.isNotEmpty() }?.let { return it }
+                }
+                val partId = c.getLong(c.getColumnIndexOrThrow("_id"))
+                try {
+                    applicationContext.contentResolver.openInputStream("content://mms/part/$partId".toUri())
+                        ?.bufferedReader()?.use { it.readText() }?.takeIf { it.isNotEmpty() }?.let { return it }
+                } catch (_: Exception) {}
+            }
             null
-        )
+        }
+    } catch (_: Exception) { null }
 
-        partsCursor?.use { cursor ->
-            while (cursor.moveToNext()) {
-                val partId = cursor.getLong(cursor.getColumnIndexOrThrow("_id"))
-                val ctIndex = cursor.getColumnIndex("ct")
-                val contentType = if (ctIndex >= 0) cursor.getString(ctIndex) ?: "" else ""
-
-                // Look for text content
-                if (contentType.startsWith("text/") || contentType == "application/smil") {
-                    // Try to get text directly from the text column
-                    val textIndex = cursor.getColumnIndex("text")
-                    if (textIndex >= 0) {
-                        val text = cursor.getString(textIndex)
-                        if (!text.isNullOrEmpty()) {
-                            return text
+    private fun extractTextFromRcsJson(json: String): String? = try {
+        val obj = org.json.JSONObject(json)
+        obj.optString("text").takeIf { it.isNotEmpty() }
+            ?: obj.optJSONObject("message")?.optString("text")?.takeIf { it.isNotEmpty() }
+            ?: run {
+                val texts = mutableListOf<String>()
+                val skipKeys = setOf("media", "suggestions", "postback", "urlAction")
+                val textKeys = listOf("text", "message", "body", "title", "description", "content", "caption")
+                fun extract(any: Any?, depth: Int = 0) {
+                    if (depth > 10) return
+                    when (any) {
+                        is org.json.JSONObject -> {
+                            textKeys.forEach { k -> any.optString(k).takeIf { it.isNotEmpty() && !it.startsWith("{") }?.let { texts.add(it) } }
+                            any.keys().forEach { k -> if (k !in skipKeys) try { extract(any.get(k), depth + 1) } catch (_: Exception) {} }
                         }
-                    }
-
-                    // Try to read from _data path (file storage)
-                    val dataIndex = cursor.getColumnIndex("_data")
-                    if (dataIndex >= 0) {
-                        val dataPath = cursor.getString(dataIndex)
-                        if (!dataPath.isNullOrEmpty()) {
-                            // Try to read the file
-                            try {
-                                val partUri = Uri.parse("content://mms/part/$partId")
-                                val inputStream =
-                                    applicationContext.contentResolver.openInputStream(partUri)
-                                val text = inputStream?.bufferedReader()?.use { it.readText() }
-                                if (!text.isNullOrEmpty()) {
-                                    return text
-                                }
-                            } catch (e: Exception) {
-                                // Ignore read errors
-                            }
-                        }
+                        is org.json.JSONArray -> for (i in 0 until any.length()) extract(any.get(i), depth + 1)
                     }
                 }
+                extract(obj)
+                texts.distinct().joinToString(" | ").takeIf { it.isNotEmpty() }
             }
-        }
+    } catch (_: Exception) { json }
 
-        null
-    } catch (e: Exception) {
-        Log.e(TAG, "Error getting RCS message text: ${e.message}", e)
-        null
-    }
+    private fun buildSummary(stats: ProcessingStats) = """
+        ┌─────── SMS Worker Complete ──────────────────
+        │  Total     : ${stats.total}
+        │  Processed : ${stats.processed.get()}
+        │  Parsed    : ${stats.parsed.get()}
+        │  Saved     : ${stats.saved.get()}
+        │  Elapsed   : ${stats.elapsedMs()}ms
+        │  Speed     : ${"%.1f".format(stats.msgPerSec())} msg/s
+        └──────────────────────────────────────────────
+    """.trimIndent()
 }
 
-/**
- * Extracts text content from RCS JSON (Rich Cards)
- */
-private fun extractTextFromRcsJson(json: String): String? {
-    return try {
-        val jsonObject = org.json.JSONObject(json)
-        val texts = mutableListOf<String>()
-
-        // Navigate through the JSON structure to find text
-        fun extractTexts(obj: Any?, depth: Int = 0) {
-            if (depth > 10) return // Prevent infinite recursion
-
-            when (obj) {
-                is org.json.JSONObject -> {
-                    // Priority order for text fields
-                    val textFields = listOf(
-                        "text",           // Plain text message
-                        "message",        // Message body
-                        "body",           // Body content
-                        "title",          // Card title
-                        "description",    // Card description
-                        "content",        // Content field
-                        "caption"         // Media caption
-                    )
-
-                    for (field in textFields) {
-                        if (obj.has(field)) {
-                            val value = obj.getString(field)
-                            if (value.isNotEmpty() && !value.startsWith("{")) {
-                                texts.add(value)
-                            }
-                        }
-                    }
-
-                    // Recursively search nested objects
-                    obj.keys().forEach { key ->
-                        if (key !in listOf("media", "suggestions", "postback", "urlAction")) {
-                            try {
-                                extractTexts(obj.get(key), depth + 1)
-                            } catch (e: Exception) {
-                                // Skip problematic fields
-                            }
-                        }
-                    }
-                }
-
-                is org.json.JSONArray -> {
-                    for (i in 0 until obj.length()) {
-                        extractTexts(obj.get(i), depth + 1)
-                    }
-                }
-            }
-        }
-
-        // Check if it's a simple text message (not a rich card)
-        if (jsonObject.has("text")) {
-            return jsonObject.getString("text")
-        }
-
-        // Check for message.text structure
-        if (jsonObject.has("message")) {
-            val message = jsonObject.getJSONObject("message")
-            if (message.has("text")) {
-                return message.getString("text")
-            }
-        }
-
-        // Extract from complex structures
-        extractTexts(jsonObject)
-
-        // Combine all found texts
-        if (texts.isNotEmpty()) {
-            return texts.distinct().joinToString(" | ")
-        }
-
-        // If no text found, it might be a media-only message
-        null
-    } catch (e: Exception) {
-        Log.e(TAG, "Error parsing RCS JSON: ${e.message}")
-        // Not JSON, return as plain text
-        json
-    }
-}
-
-data class ProcessingResult(
-    val processedCount: Int,
-    val parsedCount: Int,
-    val savedCount: Int,
-    val subscriptionCount: Int,
-    val coroutineId: Int,
-    val batchNumber: Int
-)
-
-private data class SmsMessage(
-    val id: Long,
-    val sender: String,
-    val timestamp: Long,
-    val body: String,
-    val type: Int
-)
-}
+private fun Long.toLocalDateTime() = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(this), java.time.ZoneId.systemDefault())

--- a/app/src/test/java/com/ritesh/cashiro/data/manager/TransactionDeduplicationTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/data/manager/TransactionDeduplicationTest.kt
@@ -1,0 +1,167 @@
+package com.ritesh.cashiro.data.manager
+
+import com.ritesh.cashiro.data.database.entity.TransactionEntity
+import com.ritesh.cashiro.data.database.entity.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+class TransactionDeduplicationTest {
+
+    private val baseTime = LocalDateTime.of(2025, 12, 26, 19, 2, 1)
+
+    @Test
+    fun `matches same UPI reference from partner and account bank`() {
+        val partnerBank = transaction(
+            id = 1,
+            bankName = "State Bank of India",
+            dateTime = baseTime,
+            balanceAfter = null
+        )
+        val accountBank = transaction(
+            id = 2,
+            bankName = "South Indian Bank",
+            dateTime = baseTime.plusMinutes(2),
+            balanceAfter = BigDecimal("34567.67")
+        )
+
+        assertTrue(TransactionDeduplication.isSameUpiTransaction(partnerBank, accountBank))
+        assertTrue(TransactionDeduplication.shouldReplaceWithIncoming(partnerBank, accountBank))
+    }
+
+    @Test
+    fun `does not replace account bank transaction with partner bank transaction`() {
+        val accountBank = transaction(
+            id = 1,
+            bankName = "South Indian Bank",
+            dateTime = baseTime,
+            balanceAfter = null
+        )
+        val partnerBank = transaction(
+            id = 2,
+            bankName = "State Bank of India",
+            dateTime = baseTime.plusMinutes(2),
+            balanceAfter = BigDecimal("34567.67")
+        )
+
+        assertTrue(TransactionDeduplication.isSameUpiTransaction(accountBank, partnerBank))
+        assertFalse(TransactionDeduplication.shouldReplaceWithIncoming(accountBank, partnerBank))
+    }
+
+    @Test
+    fun `does not match outside duplicate window`() {
+        val first = transaction(id = 1, dateTime = baseTime)
+        val later = transaction(id = 2, dateTime = baseTime.plusMinutes(4))
+
+        assertFalse(TransactionDeduplication.isSameUpiTransaction(first, later))
+    }
+
+    @Test
+    fun `does not match different account with same reference`() {
+        val first = transaction(id = 1, accountNumber = "2468")
+        val otherAccount = transaction(id = 2, accountNumber = "1357")
+
+        assertFalse(TransactionDeduplication.isSameUpiTransaction(first, otherAccount))
+    }
+
+    @Test
+    fun `does not match non UPI references`() {
+        val first = transaction(id = 1, reference = "ABC123")
+        val second = transaction(id = 2, reference = "ABC123")
+
+        assertFalse(TransactionDeduplication.isSameUpiTransaction(first, second))
+    }
+
+    @Test
+    fun `cleanup keeps earliest transaction per matching time window`() {
+        val transactions = listOf(
+            transaction(id = 3, dateTime = baseTime.plusMinutes(2)),
+            transaction(id = 1, dateTime = baseTime),
+            transaction(id = 2, dateTime = baseTime.plusMinutes(1)),
+            transaction(id = 4, dateTime = baseTime.plusMinutes(10)),
+            transaction(id = 5, amount = BigDecimal("15001.00")),
+            transaction(id = 6, accountNumber = "1357")
+        )
+
+        assertEquals(listOf(2L, 3L), TransactionDeduplication.duplicateIdsToDelete(transactions))
+    }
+
+    @Test
+    fun `cleanup catches duplicate across midnight within matching window`() {
+        val beforeMidnight = LocalDateTime.of(2025, 12, 26, 23, 59, 0)
+        val transactions = listOf(
+            transaction(id = 1, dateTime = beforeMidnight),
+            transaction(id = 2, dateTime = beforeMidnight.plusMinutes(2))
+        )
+
+        assertEquals(listOf(2L), TransactionDeduplication.duplicateIdsToDelete(transactions))
+    }
+
+    @Test
+    fun `cleanup keeps account bank over earlier partner bank duplicate`() {
+        val transactions = listOf(
+            transaction(
+                id = 1,
+                bankName = "State Bank of India",
+                dateTime = baseTime,
+                balanceAfter = null
+            ),
+            transaction(
+                id = 2,
+                bankName = "South Indian Bank",
+                dateTime = baseTime.plusMinutes(2),
+                balanceAfter = BigDecimal("34567.67")
+            )
+        )
+
+        assertEquals(listOf(1L), TransactionDeduplication.duplicateIdsToDelete(transactions))
+    }
+
+    @Test
+    fun `cleanup keeps balance bearing transaction when bank priority is equal`() {
+        val transactions = listOf(
+            transaction(
+                id = 1,
+                bankName = "South Indian Bank",
+                dateTime = baseTime,
+                balanceAfter = null
+            ),
+            transaction(
+                id = 2,
+                bankName = "South Indian Bank",
+                dateTime = baseTime.plusMinutes(1),
+                balanceAfter = BigDecimal("34567.67")
+            )
+        )
+
+        assertEquals(listOf(1L), TransactionDeduplication.duplicateIdsToDelete(transactions))
+    }
+
+    private fun transaction(
+        id: Long,
+        amount: BigDecimal = BigDecimal("15000.00"),
+        accountNumber: String = "2468",
+        bankName: String = "South Indian Bank",
+        reference: String = "111222333444",
+        dateTime: LocalDateTime = baseTime,
+        balanceAfter: BigDecimal? = BigDecimal("34567.67")
+    ): TransactionEntity = TransactionEntity(
+        id = id,
+        amount = amount,
+        merchantName = "Sample Merchant",
+        category = "Others",
+        transactionType = TransactionType.INCOME,
+        dateTime = dateTime,
+        smsBody = "sample sms",
+        bankName = bankName,
+        smsSender = "SIBSMS",
+        accountNumber = accountNumber,
+        balanceAfter = balanceAfter,
+        transactionHash = "hash-$id",
+        currency = "INR",
+        reference = reference
+    )
+}

--- a/app/src/test/java/com/ritesh/cashiro/data/parser/pdf/GPayPdfParserTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/data/parser/pdf/GPayPdfParserTest.kt
@@ -1,0 +1,113 @@
+package com.ritesh.cashiro.data.parser.pdf
+
+import com.ritesh.parser.core.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+class GPayPdfParserTest {
+
+    private val parser = GPayPdfParser()
+
+    private val ist = TimeZone.getTimeZone("Asia/Kolkata")
+    private val dateFormat = SimpleDateFormat("dd MMM, yyyy hh:mm a", Locale.ENGLISH).apply {
+        timeZone = ist
+    }
+
+    private fun epochForIstDate(text: String): Long = dateFormat.parse(text)!!.time
+
+    private val statementText = """
+        Google Pay Statement
+        01 Sep,
+        2025
+        03:02 PM
+        Paid to Starbucks
+        ₹450
+        UPI Transaction ID: 123456789012
+        Paid by HDFC Bank 1234
+        02 Sep,
+        2025
+        11:30 AM
+        Received from Alice
+        ₹2,000
+        UPI Transaction ID: 223456789012
+        Paid to HDFC Bank 1234
+        03 Sep,
+        2025
+        07:45 PM
+        Paid to Amazon
+        ₹1,250.50
+        UPI Transaction ID: 323456789012
+        Paid by HDFC Bank 1234
+    """.trimIndent()
+
+    @Test
+    fun `parser handles the fixture`() {
+        assertTrue("canHandle should recognise the GPay statement", parser.canHandle(statementText))
+    }
+
+    @Test
+    fun `parses all three transactions`() {
+        val txs = parser.parse(statementText)
+        assertEquals(3, txs.size)
+    }
+
+    @Test
+    fun `each transaction gets its own correct timestamp - issue 250 regression`() {
+        val txs = parser.parse(statementText)
+        assertEquals(3, txs.size)
+
+        val expected1 = epochForIstDate("01 Sep, 2025 03:02 PM")
+        val expected2 = epochForIstDate("02 Sep, 2025 11:30 AM")
+        val expected3 = epochForIstDate("03 Sep, 2025 07:45 PM")
+
+        assertEquals("txn1 should parse to 01 Sep 2025 03:02 PM IST", expected1, txs[0].timestamp)
+        assertEquals("txn2 should parse to 02 Sep 2025 11:30 AM IST", expected2, txs[1].timestamp)
+        assertEquals("txn3 should parse to 03 Sep 2025 07:45 PM IST", expected3, txs[2].timestamp)
+    }
+
+    @Test
+    fun `last transaction does not fall back to current time`() {
+        val txs = parser.parse(statementText)
+        val lastTimestamp = txs.last().timestamp
+        val now = System.currentTimeMillis()
+        val diff = Math.abs(now - lastTimestamp)
+        assertTrue(
+            "Last timestamp ($lastTimestamp) looks like current time ($now) — fallback regression",
+            diff > 24L * 60 * 60 * 1000
+        )
+    }
+
+    @Test
+    fun `merchant type and account are extracted correctly`() {
+        val txs = parser.parse(statementText)
+
+        assertEquals("Starbucks", txs[0].merchant)
+        assertEquals(TransactionType.EXPENSE, txs[0].type)
+        assertEquals(BigDecimal("450"), txs[0].amount)
+        assertEquals("1234", txs[0].accountLast4)
+
+        assertEquals("Alice", txs[1].merchant)
+        assertEquals(TransactionType.INCOME, txs[1].type)
+        assertEquals(BigDecimal("2000"), txs[1].amount)
+
+        assertEquals("Amazon", txs[2].merchant)
+        assertEquals(TransactionType.EXPENSE, txs[2].type)
+        assertEquals(BigDecimal("1250.50"), txs[2].amount)
+    }
+
+    @Test
+    fun `middle transactions do not borrow next transaction's date`() {
+        val txs = parser.parse(statementText)
+        val txn2 = txs[1]
+        val expected = epochForIstDate("02 Sep, 2025 11:30 AM")
+        val notExpected = epochForIstDate("03 Sep, 2025 07:45 PM")
+        assertEquals(expected, txn2.timestamp)
+        assertNotEquals(notExpected, txn2.timestamp)
+    }
+}

--- a/parser-core/build.gradle.kts
+++ b/parser-core/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
 group = "com.ritesh.cashiro"
 version = "0.1.0-SNAPSHOT"
 
-// Use root project's Java toolchain; avoid forcing downloads here
+kotlin {
+    jvmToolchain(21)
+}
 
 publishing {
     publications {

--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/PNBBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/PNBBankParser.kt
@@ -1,5 +1,6 @@
 package com.ritesh.parser.core.bank
 
+import com.ritesh.parser.core.MandateInfo
 import com.ritesh.parser.core.ParsedTransaction
 import com.ritesh.parser.core.TransactionType
 import java.math.BigDecimal
@@ -42,6 +43,20 @@ class PNBBankParser : BankParser() {
     }
 
     override fun extractAmount(message: String): BigDecimal? {
+        // Handle "a/c no XX340 is debited for Rs 7519" pattern
+        val debitedForPattern = Regex(
+            """debited\s+for\s+(?:Rs\.?|INR)\s*([0-9,]+(?:\.\d{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        debitedForPattern.find(message)?.let { match ->
+            val amount = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amount)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
         // Handle explicit debit of initial amount in auto-pay messages
         val initialDebitPattern = Regex(
             """initial\s+amount\s+of\s+(?:Rs\.?|INR)\s*([0-9,]+(?:\.\d{2})?)\s+has\s+been\s+debited""",
@@ -71,9 +86,9 @@ class PNBBankParser : BankParser() {
         }
 
         // Handle debit patterns - both "Rs." and "INR" formats
-        // Expanded to handle optional space after currency and different spacing
+        // "with" is optional for backward compatibility ("debited Rs. X" and "debited with Rs. X")
         val debitPattern = Regex(
-            """debited\s+with\s+(?:Rs\.?|INR)\s*([0-9,]+(?:\.\d{2})?)""",
+            """debited\s+(?:with\s+)?(?:Rs\.?|INR)\s*([0-9,]+(?:\.\d{2})?)""",
             RegexOption.IGNORE_CASE
         )
         debitPattern.find(message)?.let { match ->
@@ -111,16 +126,65 @@ class PNBBankParser : BankParser() {
     override fun extractTransactionType(message: String): TransactionType? {
         val lowerMessage = message.lowercase()
 
-        // Explicitly handle Auto-Pay and UPI-Mandate as EXPENSE if they imply a payment/debit
-        if (lowerMessage.contains("auto pay facility") || lowerMessage.contains("upi-mandate")) {
+        if (isUPIMandateNotification(message)) {
+            return null
+        }
+
+        if (lowerMessage.contains("auto pay facility") && lowerMessage.contains("debited")) {
             return TransactionType.EXPENSE
         }
 
         return super.extractTransactionType(message)
     }
 
+    fun isUPIMandateNotification(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+        return (lowerMessage.contains("upi-mandate") || lowerMessage.contains("upi mandate")) &&
+            lowerMessage.contains("successfully created")
+    }
+
+    fun parseUPIMandateSubscription(message: String): UPIMandateInfo? {
+        if (!isUPIMandateNotification(message)) {
+            return null
+        }
+
+        val amountPattern = Regex(
+            """for\s+(?:Rs\.?|INR)\s*([0-9,]+(?:\.\d{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        val amount = amountPattern.find(message)?.groupValues?.get(1)?.replace(",", "")?.let {
+            try {
+                BigDecimal(it)
+            } catch (_: NumberFormatException) {
+                null
+            }
+        } ?: return null
+
+        val merchant = Regex(
+            """towards\s+(.+?)\s+for\s+(?:Rs\.?|INR)""",
+            RegexOption.IGNORE_CASE
+        ).find(message)?.groupValues?.get(1)?.trim()?.let(::cleanMerchantName)
+            ?.takeIf(::isValidMerchantName)
+            ?: return null
+
+        val umn = Regex("""UMN:?\s*([^.\s]+)""", RegexOption.IGNORE_CASE)
+            .find(message)
+            ?.groupValues
+            ?.get(1)
+
+        return UPIMandateInfo(
+            amount = amount,
+            nextDeductionDate = null,
+            merchant = merchant,
+            umn = umn
+        )
+    }
+
     override fun extractMerchant(message: String, sender: String): String? {
-        // Extract merchant from Auto-Pay activation: from Google Clouds
+        if (message.contains("IMPS", ignoreCase = true)) {
+            return "IMPS Transfer"
+        }
+
         val fromMerchantPattern = Regex(
             """auto\s+pay.*?activated.*?from\s+([^.]+?)(?:\s+An\s+initial|\.|$)""",
             RegexOption.IGNORE_CASE
@@ -129,30 +193,17 @@ class PNBBankParser : BankParser() {
             return match.groupValues[1].trim()
         }
 
-        // Extract merchant from UPI-Mandate: towards Google
         val towardsPattern = Regex(
-            """UPI-Mandate.*towards\s+([^\s]+)\s+for""",
+            """UPI-Mandate.*towards\s+(.+?)\s+for""",
             RegexOption.IGNORE_CASE
         )
         towardsPattern.find(message)?.let { match ->
             return match.groupValues[1].trim()
         }
 
-        // Extract card info if available: thru card XX9239
         val cardPattern = Regex("""thru\s+card\s+([X\*]+\d{4})""", RegexOption.IGNORE_CASE)
         cardPattern.find(message)?.let { match ->
             return "Card ${match.groupValues[1]}"
-        }
-
-        val fromPattern = Regex(
-            """From\s+([^/]+)/""",
-            RegexOption.IGNORE_CASE
-        )
-        fromPattern.find(message)?.let { match ->
-            val merchant = cleanMerchantName(match.groupValues[1].trim())
-            if (isValidMerchantName(merchant)) {
-                return merchant
-            }
         }
 
         if (message.contains("PNB ATM", ignoreCase = true)) {
@@ -171,7 +222,14 @@ class PNBBankParser : BankParser() {
     }
 
     override fun extractAccountLast4(message: String): String? {
-        // Handle variations: Ac, A/c, Card followed by X/dots/spaces and then digits (4 to 16)
+        val acNoPattern = Regex(
+            """(?:a/c\s+no|A/c)\s+[X*]+(\d{2,4})""",
+            RegexOption.IGNORE_CASE
+        )
+        acNoPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
         val acPattern = Regex(
             """(?:A/c(?:\s*No\.)?|Ac|Card)\s*(?:[X\*]+)?(\d{4,16})""",
             RegexOption.IGNORE_CASE
@@ -184,11 +242,36 @@ class PNBBankParser : BankParser() {
     }
 
     override fun extractReference(message: String): String? {
+        if (message.contains("IMPS", ignoreCase = true)) {
+            val impsRefPattern = Regex(
+                """IMPS\s+\w*\s*Ref\s*(?:no\.?\s*)?(\d{6,})""",
+                RegexOption.IGNORE_CASE
+            )
+            impsRefPattern.find(message)?.let { match ->
+                return match.groupValues[1]
+            }
+            val impsFallback = Regex(
+                """IMPS[^0-9]*(\d{12,})""",
+                RegexOption.IGNORE_CASE
+            )
+            impsFallback.find(message)?.let { match ->
+                return match.groupValues[1]
+            }
+        }
+
         val neftRefPattern = Regex(
             """ref\s+no\.\s+([A-Z0-9]+)""",
             RegexOption.IGNORE_CASE
         )
         neftRefPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
+        val upiRefIdPattern = Regex(
+            """UPI\s+Ref\s+ID:?\s*(\d+)""",
+            RegexOption.IGNORE_CASE
+        )
+        upiRefIdPattern.find(message)?.let { match ->
             return match.groupValues[1]
         }
 
@@ -238,11 +321,11 @@ class PNBBankParser : BankParser() {
     override fun isTransactionMessage(message: String): Boolean {
         val lowerMessage = message.lowercase()
 
-        if (lowerMessage.contains("auto pay facility") && lowerMessage.contains("debited")) {
-            return true
+        if (isUPIMandateNotification(message)) {
+            return false
         }
 
-        if (lowerMessage.contains("upi-mandate") && lowerMessage.contains("successfully created")) {
+        if (lowerMessage.contains("auto pay facility") && lowerMessage.contains("debited")) {
             return true
         }
 
@@ -250,6 +333,19 @@ class PNBBankParser : BankParser() {
             return true
         }
 
+        if (lowerMessage.contains("imps") && lowerMessage.contains("debited")) {
+            return true
+        }
+
         return super.isTransactionMessage(message)
+    }
+
+    data class UPIMandateInfo(
+        override val amount: BigDecimal,
+        override val nextDeductionDate: String?,
+        override val merchant: String,
+        override val umn: String?
+    ) : MandateInfo {
+        override val dateFormat = "dd-MMM-yy"
     }
 }

--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParser.kt
@@ -110,7 +110,7 @@ class SouthIndianBankParser : BankParser() {
             )
         ) {
             // Pattern for "Info: IMPS/FDRL/528005821348/EPIFI ACCOUN." - capture everything up to period
-            val impsPattern = Regex("""Info:\s*IMPS/[^/]+/[^/]+/([^.]+)""", RegexOption.IGNORE_CASE)
+            val impsPattern = Regex("""Info:\s*IMPS/[^/]+/[^/]+/([^,\s]+)""", RegexOption.IGNORE_CASE)
             impsPattern.find(message)?.let { match ->
                 val merchant = match.groupValues[1].trim()
                 if (merchant.isNotEmpty()) {

--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParser.kt
@@ -123,7 +123,7 @@ class SouthIndianBankParser : BankParser() {
         if (message.contains("UPI", ignoreCase = true)) {
             // Pattern for "Info:UPI/IPOS/number/MERCHANT NAME on" format
             val infoPattern =
-                Regex("""Info:UPI/[^/]+/[^/]+/([^/]+?)\s+on""", RegexOption.IGNORE_CASE)
+                Regex("""Info:\s*UPI/[^/]+/\d{12}/\s*([^/]+?)\s+on""", RegexOption.IGNORE_CASE)
             infoPattern.find(message)?.let { match ->
                 val merchant = match.groupValues[1].trim()
                 if (merchant.isNotEmpty()) {
@@ -229,13 +229,33 @@ class SouthIndianBankParser : BankParser() {
                 ignoreCase = true
             )
         ) {
-            val impsRefPattern = Regex("""Info:\s*IMPS/[^/]+/([^/]+)/""", RegexOption.IGNORE_CASE)
+            val impsRefPattern = Regex(
+                """Info:\s*IMPS/[^/]+/(\d+)(?:/\s*|\s+)""",
+                RegexOption.IGNORE_CASE
+            )
             impsRefPattern.find(message)?.let { match ->
                 val ref = match.groupValues[1].trim()
                 if (ref.isNotEmpty()) {
                     return ref
                 }
             }
+
+            val impsRefPattern2 = Regex("""Info:\s*IMPS/[^/]+/([^/]+)/""", RegexOption.IGNORE_CASE)
+            impsRefPattern2.find(message)?.let { match ->
+                val ref = match.groupValues[1].trim()
+                if (ref.isNotEmpty() && ref.all { it.isDigit() }) {
+                    return ref
+                }
+            }
+        }
+
+        // Pattern for UPI reference in "Info: UPI/provider/rrn/..." format.
+        val upiInfoPattern = Regex(
+            """Info:\s*UPI/[^/]+/(\d{12})(?:/|\s|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        upiInfoPattern.find(message)?.let { match ->
+            return match.groupValues[1].trim()
         }
 
         // Pattern for RRN (e.g., "RRN:523273398527" or "RRN:567304295699.")

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/PNBBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/PNBBankParserTest.kt
@@ -5,8 +5,12 @@ import com.ritesh.parser.core.bank.PNBBankParser
 import com.ritesh.parser.core.test.ExpectedTransaction
 import com.ritesh.parser.core.test.ParserTestCase
 import com.ritesh.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.DynamicTest.dynamicTest
 import java.math.BigDecimal
 
 class PNBBankParserTest {
@@ -84,15 +88,56 @@ class PNBBankParserTest {
                 )
             ),
             ParserTestCase(
-                name = "UPI-Mandate creation message",
-                message = "Your UPI-Mandate is successfully created towards Google for Rs.1500.00 from A/c No.XXXXXX4356. UMN:1d478c77808c410281f435rer5qwerty6@ybl-PNB",
-                sender = "AX-PNBSMS-S",
+                name = "IMPS transfer debit message",
+                message = "Your a/c no XX1234 is debited for Rs 1000 on 01-01-25 12:00:00 and a/c XX456 credited (IMPS Ref no 123456789012) .If not done by you, pl. forward this SMS from registered mobile to 9264092640 to report unauthorized txn & block IBS/MBS. Download PNB ONE.-PNB",
+                sender = "VM-PNBSMS-S",
                 expected = ExpectedTransaction(
-                    amount = BigDecimal("1500.00"),
+                    amount = BigDecimal("1000"),
                     currency = "INR",
                     type = TransactionType.EXPENSE,
-                    accountLast4 = "4356",
-                    merchant = "Google"
+                    accountLast4 = "1234",
+                    reference = "123456789012",
+                    merchant = "IMPS Transfer"
+                )
+            ),
+            ParserTestCase(
+                name = "IMPS transfer debit to different account",
+                message = "Your a/c no XX847 is debited for Rs 3200 on 11-07-25 03:14:52 and a/c XX291 credited (IMPS Ref no 712845931206) .If not done by you, pl. forward this SMS from registered mobile to 9264092640 to report unauthorized txn & block IBS/MBS. Download PNB ONE.-PNB",
+                sender = "VM-PNBSMS-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3200"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "847",
+                    reference = "712845931206",
+                    merchant = "IMPS Transfer"
+                )
+            ),
+            ParserTestCase(
+                name = "IMPS transfer original message format",
+                message = "Your a/c no XX847 is debited for Rs 6140 on 15-07-25 09:37:44 and a/c XX583 credited (IMPS Ref no 713092476185) .If not done by you, pl. forward this SMS from registered mobile to 9264092640 to report unauthorized txn & block IBS/MBS. Download PNB ONE.-PNB",
+                sender = "VM-PNBSMS-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("6140"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "847",
+                    reference = "713092476185",
+                    merchant = "IMPS Transfer"
+                )
+            ),
+            ParserTestCase(
+                name = "UPI credit message with Ref ID",
+                message = "Ac XX7582 Credited with Rs.4750.00 11-07-2025 08:53:21 thru UPI . Aval Bal Rs.82431.67 CR. (UPI Ref ID:714628305917) Helpline 18001800/18002021-PNB",
+                sender = "VM-PNBSMS-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4750.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "7582",
+                    reference = "714628305917",
+                    balance = BigDecimal("82431.67"),
+                    merchant = "UPI Transaction"
                 )
             )
         )
@@ -106,12 +151,35 @@ class PNBBankParserTest {
             "UNKNOWN" to false
         )
 
-
         return ParserTestUtils.runTestSuite(
             parser = parser,
             testCases = testCases,
             handleCases = handleChecks,
             suiteName = "PNB Parser"
+        )
+    }
+
+    @TestFactory
+    fun `pnb mandate creation is treated as subscription not expense`(): List<DynamicTest> {
+        val parser = PNBBankParser()
+        val sender = "AX-PNBSMS-S"
+        val message =
+            "Your UPI-Mandate is successfully created towards Google for Rs.1500.00 from A/c No.XXXXXX4356. UMN:1d478c77808c410281f435rer5qwerty6@ybl-PNB"
+
+        return listOf(
+            dynamicTest("detect mandate notification") {
+                assertEquals(true, parser.isUPIMandateNotification(message))
+            },
+            dynamicTest("do not parse mandate creation as transaction") {
+                assertNull(parser.parse(message, sender, System.currentTimeMillis()))
+            },
+            dynamicTest("parse mandate subscription details") {
+                val mandate = parser.parseUPIMandateSubscription(message)
+                assertNotNull(mandate)
+                assertEquals(BigDecimal("1500.00"), mandate?.amount)
+                assertEquals("Google", mandate?.merchant)
+                assertEquals("1d478c77808c410281f435rer5qwerty6@ybl-PNB", mandate?.umn)
+            }
         )
     }
 }

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParserTest.kt
@@ -77,6 +77,20 @@ class SouthIndianBankParserTest {
                     balance = BigDecimal("35037.21"),
                     reference = "567304295699"
                 )
+            ),
+            ParserTestCase(
+                name = "IMPS credit with different bank code and merchant",
+                message = "Dear Customer, Your A/c X1234 is credited with Rs.1000.00 Info: IMPS/PUNB/123456789012/ METRO TRADERS. Final balance is Rs.10000.00-South Indian Bank",
+                sender = "SIBSMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "1234",
+                    balance = BigDecimal("10000.00"),
+                    reference = "123456789012",
+                    merchant = "METRO TRADERS"
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/SouthIndianBankParserTest.kt
@@ -79,6 +79,34 @@ class SouthIndianBankParserTest {
                 )
             ),
             ParserTestCase(
+                name = "UPI credit extracts reference from info path",
+                message = "UPI Credit:INR Rs.15000.00 in A/c X2468. Info: UPI/TGRB/111222333444/ Sample Payer on 26-12-25 19:02:01.Final balance is Rs.34567.67 -South Indian Bank",
+                sender = "SIBSMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("15000.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "Sample Payer",
+                    accountLast4 = "2468",
+                    balance = BigDecimal("34567.67"),
+                    reference = "111222333444"
+                )
+            ),
+            ParserTestCase(
+                name = "UPI debit extracts reference from compact info path",
+                message = "UPI debit:INR Rs.250.50 in A/c X2468. Info:UPI/ICIC/222333444555/Demo Merchant on 26-12-25 19:05:01. Final balance is Rs.34317.17 -South Indian Bank",
+                sender = "VM-SIBSMS-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("250.50"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Demo Merchant",
+                    accountLast4 = "2468",
+                    balance = BigDecimal("34317.17"),
+                    reference = "222333444555"
+                )
+            ),
+            ParserTestCase(
                 name = "IMPS credit with different bank code and merchant",
                 message = "Dear Customer, Your A/c X1234 is credited with Rs.1000.00 Info: IMPS/PUNB/123456789012/ METRO TRADERS. Final balance is Rs.10000.00-South Indian Bank",
                 sender = "SIBSMS",


### PR DESCRIPTION
## Summary
Work in progress,not ready yet,still working on porting over
This PR is an exhaustive backport of upstream improvements from the **Pennywise** codebase (PR #220 + PR #338) to Cashiro, delivering **parity, performance gains, critical bugfixes, and UPI duplicate deduplication** across the SMS reader pipeline, bank parsers, UI, and build configuration.

## Key Changes

### OptimizedSmsReaderWorker — Channel-based Pipeline
- **~1700 lines → ~460 lines**: Replaced the batch-based processing loop with a `Channel<ParseResult>` pipeline architecture
- **Parallel parsing**: SMS messages are parsed concurrently on `Dispatchers.IO`, results are saved sequentially by a single consumer
- **Pre-loaded caches**: Merchant mapping and rule caches are loaded once at startup instead of querying per-SMS
- **RCS support**: New helpers for reading RCS messages — `readRcsMessages()`, `extractRcsSender()`, `getRcsMessageText()`, `extractTextFromRcsJson()`
- **Cleaner subscription processing**: Per-bank subscription handlers (SBI, Federal, HDFC, Indian Bank, PNB, ICICI)
- **Dedup-by-hash**: `saveTransaction()` checks transaction hash before inserting
- **Unrecognized batch flush**: `flushUnrecognizedBatch()` handles unknown `-T`/`-S` senders
- **UPI duplicate dedup**: `SaveOutcome` enum with `SAVED`/`UPDATED_DUPLICATE`/`SKIPPED_DUPLICATE`/`SKIPPED`, `cleanupExistingGPayDuplicates()` for post-scan cleanup

### Bank Parser Fixes
- **PNBBankParser**: IMPS amount extraction (`debited for Rs`), UPI-Mandate detection and subscription parsing, IMPS reference/merchant extraction, UPI Ref ID pattern, Aval Bal / Avl Bal balance patterns, `UPIMandateInfo` data class
- **SouthIndianBankParser**: Fixed IMPS merchant regex to properly capture merchant names containing dots (e.g. `METRO TRADERS`); robust IMPS reference extraction with digit-only + fallback patterns

### UPI Duplicate Deduplication
- **TransactionDeduplication**: New utility with `isSameUpiTransaction()`, `shouldReplaceWithIncoming()`, `duplicateIdsToDelete()` — detects GPay UPI duplicates within a 2-minute window using 12-digit RRN
- **TransactionDeduplicationTest**: 8 unit tests covering identical, window-miss, different-amount, upi-replace scenarios
- **TransactionDao**: `findPotentialDuplicatesByReference()` with both reference+amount matching and GLOB-based RRN cleanup
- **TransactionRepository**: `findPotentialDuplicates(transaction)` and `findGPayDuplicateIdsForCleanup()`
- **TransactionEntity**: Added nullable `reference` column
- **Database migration**: v51→52 (`ALTER TABLE transactions ADD COLUMN reference TEXT`)
- **AccountBalanceDao/Repository**: `deleteBalancesForTransaction()` to clean up balances when replacing duplicates
- **RuleRepository**: `deleteRuleApplicationsForTransaction()` — cleans up stale rule applications

### UI
- **TransactionDetailScreen**: Added Reference row in TransactionReceipt showing `transaction.reference` or `transaction.smsSender` fallback

### PDF Parser
- **PdfStatementParser (GPayPdfParser)**: Full rewrite to line-based pipeline with transaction anchor splitting, date buffer zone, and improved bank/account detection

### DAO / Repository
- **MerchantMappingDao**: Added `getAllMappingsList()` returning `List<MerchantMappingEntity>`
- **MerchantMappingRepository**: Added `getAllMappingsAsMap()` returning `Map<String, String>`

### Build
- **app/build.gradle.kts**: Added `packaging.resources.excludes` for META-INF license files
- **parser-core/build.gradle.kts**: Added `jvmToolchain(21)`

### Tests (all passing)
- **PNBBankParserTest**: Complete test suite (10 transaction patterns + mandate subscription tests) using `ParserTestUtils` with `@TestFactory`
- **SouthIndianBankParserTest**: Added IMPS credit test case with different bank code (`PUNB`); UPI credit/debit test cases with reference extraction
- **TransactionDeduplicationTest**: 8 unit tests for dedup logic

## Files Changed (cumulative)
| File | Changes |
|------|---------|
| `OptimizedSmsReaderWorker.kt` | Pipeline rewrite + UPI dedup + SaveOutcome |
| `PNBBankParser.kt` | Major enhancements |
| `PdfStatementParser.kt` | Full parse pipeline rewrite |
| `SouthIndianBankParser.kt` | IMPS merchant fix + IMPS reference extraction |
| `TransactionDetailScreen.kt` | Reference row |
| `TransactionDeduplication.kt` | New — UPI dedup utility |
| `TransactionDeduplicationTest.kt` | New — 8 unit tests |
| `TransactionEntity.kt` | `reference` column |
| `CashiroDatabase.kt` | v51→52 migration |
| `TransactionDao.kt` | `findPotentialDuplicatesByReference` |
| `ParsedTransactionMapper.kt` | Map `reference` from parser |
| `TransactionRepository.kt` | Dedup + cleanup methods |
| `AccountBalanceDao.kt` | `deleteBalancesForTransaction` |
| `AccountBalanceRepository.kt` | `deleteBalancesForTransaction` |
| `RuleRepository.kt` | `deleteRuleApplicationsForTransaction` |
| `RuleRepositoryImpl.kt` | `deleteRuleApplicationsForTransaction` |
| `PNBBankParserTest.kt` | New full test suite |
| `SouthIndianBankParserTest.kt` | New test cases |
| `MerchantMappingDao.kt` | `getAllMappingsList` |
| `MerchantMappingRepository.kt` | `getAllMappingsAsMap` |
| `app/build.gradle.kts` | packaging excludes |
| `parser-core/build.gradle.kts` | jvmToolchain |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction receipts show a Reference row when available
  * UPI mandate/subscription detection for supported banks
  * RCS/MMS message parsing support

* **Improvements**
  * Streaming SMS/RCS processing with better UPI duplicate detection and automated cleanup
  * More accurate parsing for Google Pay statements and bank-specific messages
  * Improved balance computation and account/card resolution

* **Chores**
  * Build/toolchain and packaging tweaks to exclude common license files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-kanwar/Cashiro/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->