### PR TITLE
fix(parser): improve HDFC and IOB SMS merchant parsing (#103)

### DIFF
--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/HDFCBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/HDFCBankParser.kt
@@ -192,6 +192,29 @@ class HDFCBankParser : BankParser() {
             }
         }
 
+        // Pattern 6b: HDFC UPI send format:
+        // "Sent Rs.x From HDFC Bank A/C *1234 To merchant_or_vpa On dd/MM/yy"
+        if (message.contains("Sent Rs", ignoreCase = true) &&
+            message.contains("From HDFC Bank", ignoreCase = true)
+        ) {
+            val sentToPattern = Regex(
+                """\bTo\s+(.+?)\s+On\s+\d{1,2}[/-]\d{1,2}[/-]\d{2,4}""",
+                RegexOption.IGNORE_CASE
+            )
+            sentToPattern.find(message)?.let { match ->
+                val payee = match.groupValues[1].trim()
+                val merchant = if (payee.contains("@")) {
+                    val vpaName = payee.substringBefore("@").trim()
+                    if (vpaName.any { it.isLetter() }) cleanMerchantName(vpaName) else "UPI Payee"
+                } else {
+                    cleanMerchantName(payee)
+                }
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+        }
+
         // Pattern 7: "towards [Merchant Name]" (for payment alerts)
         if (message.contains("towards", ignoreCase = true)) {
             val towardsPattern = Regex(

--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
@@ -158,6 +158,15 @@ class IndianOverseasBankParser : BankParser() {
     }
 
     override fun extractAccountLast4(message: String): String? {
+        val shortAccountPattern = Regex(
+            """\b(?:SB|CA|CC)-[xX]*(\d{2,4})\b""",
+            RegexOption.IGNORE_CASE
+        )
+        shortAccountPattern.find(message)?.let { match ->
+            val digits = match.groupValues[1]
+            return if (digits.length >= 4) digits.takeLast(4) else digits
+        }
+
         // Pattern: "Your a/c no. XXXXX92"
         val accountPattern = Regex(
             """a/c\s+no\.\s+[X]*(\d{2,4})""",

--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
@@ -64,6 +64,41 @@ class IndianOverseasBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        val bracketedDescriptionPattern = Regex("""\[\s*([^\]]+?)\s*]""", RegexOption.IGNORE_CASE)
+        bracketedDescriptionPattern.find(message)?.let { match ->
+            val description = match.groupValues[1].trim()
+            val normalizedDescription = when {
+                description.contains("CHRGS", ignoreCase = true) &&
+                    description.contains("SMS", ignoreCase = true) -> "SMS Charges"
+                description.startsWith("NEFT-", ignoreCase = true) -> {
+                    description.split("-").getOrNull(1)?.takeIf { it.isNotBlank() } ?: description
+                }
+                description.startsWith("UPI/", ignoreCase = true) -> "UPI"
+                else -> description
+            }
+            val merchant = cleanMerchantName(normalizedDescription)
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        val payeePattern = Regex(
+            """debited\s+for\s+payee\s+(.+?)\s+for\s+Rs\.?""",
+            RegexOption.IGNORE_CASE
+        )
+        payeePattern.find(message)?.let { match ->
+            val payee = match.groupValues[1].trim()
+            val merchant = if (payee.contains("@")) {
+                val vpaName = payee.substringBefore("@").trim()
+                if (vpaName.any { it.isLetter() }) cleanMerchantName(vpaName) else "UPI Payee"
+            } else {
+                cleanMerchantName(payee)
+            }
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
         // UPI transaction with payer details
         // Pattern: "from SIDDHANT SIN-7737219900@su(UPI Ref"
         val upiPayerPattern = Regex(
@@ -165,7 +200,13 @@ class IndianOverseasBankParser : BankParser() {
         if (lowerMessage.contains("otp") ||
             lowerMessage.contains("verification") ||
             lowerMessage.contains("request") ||
-            lowerMessage.contains("failed")
+            lowerMessage.contains("failed") ||
+            lowerMessage.contains("will be debited") ||
+            lowerMessage.contains("will be deducted") ||
+            lowerMessage.contains("applicable sms charges") ||
+            lowerMessage.contains("txn is not enabled") ||
+            lowerMessage.contains("transaction declined") ||
+            lowerMessage.contains("never respond")
         ) {
             return false
         }

--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
@@ -73,6 +73,9 @@ class IndianOverseasBankParser : BankParser() {
         val bracketedDescriptionPattern = Regex("""\[\s*([^\]]+?)\s*]""", RegexOption.IGNORE_CASE)
         bracketedDescriptionPattern.find(message)?.let { match ->
             val description = match.groupValues[1].trim()
+            if (description.matches(Regex("""IMPS/\s*\d+""", RegexOption.IGNORE_CASE))) {
+                return@let
+            }
             val normalizedDescription = when {
                 description.contains("CHRGS", ignoreCase = true) &&
                     description.contains("SMS", ignoreCase = true) -> "SMS Charges"
@@ -205,7 +208,7 @@ class IndianOverseasBankParser : BankParser() {
 
     override fun extractReference(message: String): String? {
         val bracketRefPattern = Regex(
-            """\[(?:UPI|IMPS)/\s*(\d+)""",
+            """\[(?:UPI|IMPS)(?:/(?:UPI|IMPS))?/\s*(\d+)""",
             RegexOption.IGNORE_CASE
         )
         bracketRefPattern.find(message)?.let { match ->

--- a/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
+++ b/parser-core/src/main/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParser.kt
@@ -24,6 +24,8 @@ class IndianOverseasBankParser : BankParser() {
     override fun extractAmount(message: String): BigDecimal? {
         // List of amount patterns for IOB
         val amountPatterns = listOf(
+            Regex("""Rs\.?\s*([0-9,]+(?:\.\d{2})?)\s+Debited\s+to\s+(?:SB|CA|CC)-""", RegexOption.IGNORE_CASE),
+            Regex("""Rs\.?\s*([0-9,]+(?:\.\d{2})?)\s+Credited\s+to\s+(?:SB|CA|CC)-""", RegexOption.IGNORE_CASE),
             // "credited by Rs.906.00"
             Regex("""credited\s+by\s+Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
             // "debited by Rs.906.00"
@@ -31,7 +33,8 @@ class IndianOverseasBankParser : BankParser() {
             // "credited with Rs.906.00"
             Regex("""credited\s+with\s+Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
             // "debited for Rs.906.00"
-            Regex("""debited\s+for\s+Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
+            Regex("""debited\s+for\s+Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
+            Regex("""debited\s+towards\s+[Xx]*\d{2,4}\s+for\s+Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
         )
 
         for (pattern in amountPatterns) {
@@ -54,10 +57,13 @@ class IndianOverseasBankParser : BankParser() {
             lowerMessage.contains("credited by") -> TransactionType.INCOME
             lowerMessage.contains("credited with") -> TransactionType.INCOME
             lowerMessage.contains("is credited") -> TransactionType.INCOME
+            lowerMessage.contains("credited to") -> TransactionType.INCOME
 
             lowerMessage.contains("debited by") -> TransactionType.EXPENSE
             lowerMessage.contains("debited for") -> TransactionType.EXPENSE
             lowerMessage.contains("is debited") -> TransactionType.EXPENSE
+            lowerMessage.contains("debited to") -> TransactionType.EXPENSE
+            lowerMessage.contains("debited towards") -> TransactionType.EXPENSE
 
             else -> super.extractTransactionType(message)
         }
@@ -158,29 +164,54 @@ class IndianOverseasBankParser : BankParser() {
     }
 
     override fun extractAccountLast4(message: String): String? {
-        val shortAccountPattern = Regex(
-            """\b(?:SB|CA|CC)-[xX]*(\d{2,4})\b""",
-            RegexOption.IGNORE_CASE
+        val accountPatterns = listOf(
+            Regex("""\b(?:SB|CA|CC)-[xX]*(\d{2,4})\b""", RegexOption.IGNORE_CASE),
+            Regex("""a/c\s+no\.\s+[Xx]*(\d{2,4})""", RegexOption.IGNORE_CASE),
+            Regex("""a/c:?\s*[Xx]*(\d{2,4})""", RegexOption.IGNORE_CASE),
+            Regex("""account\s+has\s+been\s+debited\s+towards\s+[Xx]*(\d{2,4})""", RegexOption.IGNORE_CASE),
+            Regex("""IOB\s+account\s+[Xx]*(\d{2,4})""", RegexOption.IGNORE_CASE),
+            Regex("""Acct:\s*\d*[xX]+(\d{2,4})""", RegexOption.IGNORE_CASE)
         )
-        shortAccountPattern.find(message)?.let { match ->
-            val digits = match.groupValues[1]
-            return if (digits.length >= 4) digits.takeLast(4) else digits
-        }
 
-        // Pattern: "Your a/c no. XXXXX92"
-        val accountPattern = Regex(
-            """a/c\s+no\.\s+[X]*(\d{2,4})""",
-            RegexOption.IGNORE_CASE
-        )
-        accountPattern.find(message)?.let { match ->
-            val digits = match.groupValues[1]
-            return if (digits.length >= 4) digits.takeLast(4) else digits
+        for (pattern in accountPatterns) {
+            pattern.find(message)?.let { match ->
+                val digits = match.groupValues[1]
+                return if (digits.length >= 4) digits.takeLast(4) else digits
+            }
         }
 
         return super.extractAccountLast4(message)
     }
 
+    override fun extractBalance(message: String): BigDecimal? {
+        val balancePatterns = listOf(
+            Regex("""AcBal:\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
+            Regex("""Avl\s+Balance\s+in\s+Acct:[^\s]+\s+is\s+Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in balancePatterns) {
+            pattern.find(message)?.let { match ->
+                val balance = match.groupValues[1].replace(",", "")
+                return try {
+                    BigDecimal(balance)
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return super.extractBalance(message)
+    }
+
     override fun extractReference(message: String): String? {
+        val bracketRefPattern = Regex(
+            """\[(?:UPI|IMPS)/\s*(\d+)""",
+            RegexOption.IGNORE_CASE
+        )
+        bracketRefPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
         // Pattern: "(UPI Ref no 560699645381)"
         val upiRefPattern = Regex(
             """\(UPI\s+Ref\s+no\s+(\d+)\)""",
@@ -223,8 +254,11 @@ class IndianOverseasBankParser : BankParser() {
         // Check for IOB specific transaction patterns
         if (lowerMessage.contains("is credited by") ||
             lowerMessage.contains("is debited by") ||
+            lowerMessage.contains("debited to") ||
+            lowerMessage.contains("credited to") ||
             lowerMessage.contains("credited with") ||
-            lowerMessage.contains("debited for")
+            lowerMessage.contains("debited for") ||
+            lowerMessage.contains("debited towards")
         ) {
             return true
         }

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/HDFCBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/HDFCBankParserTest.kt
@@ -40,6 +40,44 @@ T&C. Ignore if paid""",
                     accountLast4 = "1234",
                     reference = "123456789012"
                 )
+            ),
+            ParserTestCase(
+                name = "Sent UPI transaction to named payee",
+                message = """Sent Rs.45.00
+From HDFC Bank A/C *1234
+To Sample Friend
+On 23/05/26
+Ref 123456789012
+Not You?
+Contact bank support/SMS BLOCK UPI""",
+                sender = "JD-HDFCBK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("45.00"),
+                    currency = "INR",
+                    type = com.ritesh.parser.core.TransactionType.EXPENSE,
+                    merchant = "Sample Friend",
+                    accountLast4 = "1234",
+                    reference = "123456789012"
+                )
+            ),
+            ParserTestCase(
+                name = "Sent UPI transaction to numeric VPA",
+                message = """Sent Rs.70.00
+From HDFC Bank A/C *1234
+To 0000000000@bank
+On 23/05/26
+Ref 123456789013
+Not You?
+Contact bank support/SMS BLOCK UPI""",
+                sender = "AD-HDFCBK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("70.00"),
+                    currency = "INR",
+                    type = com.ritesh.parser.core.TransactionType.EXPENSE,
+                    merchant = "UPI Payee",
+                    accountLast4 = "1234",
+                    reference = "123456789013"
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
@@ -63,6 +63,83 @@ class IndianOverseasBankParserTest {
                 )
             ),
             ParserTestCase(
+                name = "Balance credit with account and AcBal",
+                message = """
+                    Rs.4740.08 Credited to SB-xxx1234 AcBal:65040.08 CLRBal: 65083.90
+                    [NEFT-CITI- ] SAMPLE-BRANCH on 20-05-2026 15:01:34.IOB.
+                """.trimIndent(),
+                sender = "JD-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4740.08"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "CITI",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("65040.08")
+                )
+            ),
+            ParserTestCase(
+                name = "UPI balance debit extracts account and balance",
+                message = """
+                    Rs.70000.00 Debited to SB-xxx1234 AcBal:8054.76 CLRBal: 8098.58
+                    [UPI/636773 ] SAMPLE-BRANCH on 01-01-2026 16:11:16.IOB.
+                """.trimIndent(),
+                sender = "VM-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("70000.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "UPI",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("8054.76"),
+                    reference = "636773"
+                )
+            ),
+            ParserTestCase(
+                name = "UPI credit detail with short masked account",
+                message = """
+                    Your a/c no. XXXXX99 is credited by Rs.10000.00 on 2026-05-04 19:35:21.874,
+                    from SAMPLE PAYER-samplepayer@bank(UPI Ref no 122603588789).Payer Remark - UPI -IOB
+                """.trimIndent(),
+                sender = "BV-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10000.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "UPI - SAMPLE PAYER (samplepayer@bank)",
+                    accountLast4 = "99",
+                    reference = "122603588789"
+                )
+            ),
+            ParserTestCase(
+                name = "Towards account debit format",
+                message = """
+                    Your account has been debited towards XXXX1234 for Rs. 4383.00 on 03/07/2025.
+                    If not you, contact tollfree 18008904445. -IOB
+                """.trimIndent(),
+                sender = "BZ-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4383.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "1234"
+                )
+            ),
+            ParserTestCase(
+                name = "IMPS credit detail format",
+                message = """
+                    Dear Customer, Your A/C:XXX1234 is credited by Rs. 1.00 on 07/07/2025
+                    from a/c XXX3413 (IMPS Ref id:518809468661)? IOB
+                """.trimIndent(),
+                sender = "AD-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "1234"
+                )
+            ),
+            ParserTestCase(
                 name = "Future SMS charge notice should not parse",
                 message = """
                     Dear Customer, Applicable SMS charges will be debited from your SB/CA/CC acct

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
@@ -1,0 +1,93 @@
+package com.ritesh.parser.core.bank
+
+import com.ritesh.parser.core.TransactionType
+import com.ritesh.parser.core.test.ExpectedTransaction
+import com.ritesh.parser.core.test.ParserTestCase
+import com.ritesh.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class IndianOverseasBankParserTest {
+    @Test
+    fun `iob parser handles debit credit and notice formats`() {
+        val parser = IndianOverseasBankParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Debited for named payee",
+                message = """
+                    Your a/c XX1234 debited for payee SAMPLE MERCHANT for Rs. 150.00
+                    on 2026-03-25, ref 123456789012.If not you, report to your bank immediately-IOB.
+                """.trimIndent(),
+                sender = "BZ-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("150.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SAMPLE MERCHANT",
+                    accountLast4 = "1234",
+                    reference = "123456789012"
+                )
+            ),
+            ParserTestCase(
+                name = "Debited for VPA payee",
+                message = """
+                    Your a/c XX1234 debited for payee samplepayee@bank for Rs. 996.00
+                    on 2026-02-03, ref 123456789013.If not you, report to your bank immediately-IOB.
+                """.trimIndent(),
+                sender = "VA-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("996.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "samplepayee",
+                    accountLast4 = "1234",
+                    reference = "123456789013"
+                )
+            ),
+            ParserTestCase(
+                name = "SMS charge debit",
+                message = """
+                    Rs.20.64 Debited to SB-xxx1234 AcBal:65162.78 CLRBal: 65206.60
+                    [CHRGS- SMS ] BRANCH ONE on 23-05-2026 08:00:39.IOB.
+                """.trimIndent(),
+                sender = "JD-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("20.64"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SMS Charges",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("65162.78")
+                )
+            ),
+            ParserTestCase(
+                name = "Future SMS charge notice should not parse",
+                message = """
+                    Dear Customer, Applicable SMS charges will be debited from your SB/CA/CC acct
+                    for the period Oct-Dec 2025. For details, pls visit our website/Branch-IOB
+                """.trimIndent(),
+                sender = "VA-IOBCHN-S",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Disabled card transaction notice should not parse",
+                message = """
+                    Dear Customer, ECOM txn is not enabled for your Debit Card xx1234.
+                    Pls enable Ecom txns using Internet Banking or by visiting your branch - IOB
+                """.trimIndent(),
+                sender = "AD-IOBCHN",
+                shouldParse = false
+            )
+        )
+
+        val handleCases = listOf(
+            "JD-IOBCHN-S" to true,
+            "IOBCHN" to true,
+            "HDFCBK" to false,
+            "" to false
+        )
+
+        ParserTestUtils.runTestSuite(parser, cases, handleCases, "Indian Overseas Bank Parser Tests")
+    }
+}

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
@@ -4,12 +4,13 @@ import com.ritesh.parser.core.TransactionType
 import com.ritesh.parser.core.test.ExpectedTransaction
 import com.ritesh.parser.core.test.ParserTestCase
 import com.ritesh.parser.core.test.ParserTestUtils
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
 import java.math.BigDecimal
 
 class IndianOverseasBankParserTest {
-    @Test
-    fun `iob parser handles debit credit and notice formats`() {
+    @TestFactory
+    fun `iob parser handles debit credit and notice formats`(): List<DynamicTest> {
         val parser = IndianOverseasBankParser()
 
         val cases = listOf(
@@ -88,6 +89,6 @@ class IndianOverseasBankParserTest {
             "" to false
         )
 
-        ParserTestUtils.runTestSuite(parser, cases, handleCases, "Indian Overseas Bank Parser Tests")
+        return ParserTestUtils.runTestSuite(parser, cases, handleCases, "Indian Overseas Bank Parser Tests")
     }
 }

--- a/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/ritesh/parser/core/bank/IndianOverseasBankParserTest.kt
@@ -96,6 +96,39 @@ class IndianOverseasBankParserTest {
                 )
             ),
             ParserTestCase(
+                name = "Pure IMPS bracket is reference not merchant",
+                message = """
+                    Rs.500.00 Debited to SB-xxx1234 AcBal:1000.00 CLRBal: 1000.00
+                    [IMPS/ 123456] SAMPLE-BRANCH on 01-01-2026 16:11:16.IOB.
+                """.trimIndent(),
+                sender = "VM-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "1234",
+                    balance = BigDecimal("1000.00"),
+                    reference = "123456"
+                )
+            ),
+            ParserTestCase(
+                name = "Combined UPI IMPS bracket extracts reference",
+                message = """
+                    Rs.250.00 Debited to SB-xxx1234 AcBal:750.00 CLRBal: 750.00
+                    [UPI/IMPS/ 654321] SAMPLE-BRANCH on 01-01-2026 16:11:16.IOB.
+                """.trimIndent(),
+                sender = "VM-IOBCHN-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("250.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "UPI",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("750.00"),
+                    reference = "654321"
+                )
+            ),
+            ParserTestCase(
                 name = "UPI credit detail with short masked account",
                 message = """
                     Your a/c no. XXXXX99 is credited by Rs.10000.00 on 2026-05-04 19:35:21.874,


### PR DESCRIPTION
## Summary

Fixes HDFC and Indian Overseas Bank SMS parser edge cases that were producing unclear merchants or saving non-transaction IOB notices.

- Extracts payees from HDFC `Sent Rs... From HDFC Bank A/C ... To ... On ...` messages.
- Uses `UPI Payee` for numeric VPA recipients instead of saving `Unknown Merchant`.
- Cleans IOB `debited for payee ... for Rs...` merchant extraction.
- Extracts useful IOB bracketed descriptions like `SMS Charges`.
- Ignores IOB notices that mention debit/transaction wording but are not actual transactions.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

Not applicable. Parser-only change.

## How to test

1. Run `./gradlew :parser-core:test`.
2. Confirm HDFC sent-payment cases parse with a usable merchant.
3. Confirm IOB payee, VPA payee, SMS charge, and notice cases pass in `IndianOverseasBankParserTest`.

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe):

## Related issues

Closes #103.

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `./gradlew test` passes locally (`./gradlew :parser-core:test`)
- [ ] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merchant extraction for HDFC UPI "Sent" messages, including VPA normalization and fallback to a generic payee label
  * Reworked Indian Overseas Bank parsing: new merchant patterns, expanded amount/type detection, broader account-last4 matching, balance and reference parsing, and extra non-transaction filters

* **Tests**
  * Added HDFC UPI sent transaction tests (named and numeric VPA)
  * Added comprehensive Indian Overseas Bank parser test suite covering many debit/credit/notice formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-kanwar/Cashiro/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->