### PR TITLE
fix(account): recalculate transaction balances

### DIFF
--- a/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
@@ -2,9 +2,16 @@ package com.ritesh.cashiro.data.database.dao
 
 import androidx.room.*
 import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
+import com.ritesh.cashiro.data.database.entity.TransactionType
 import kotlinx.coroutines.flow.Flow
 import java.math.BigDecimal
 import java.time.LocalDateTime
+
+private const val SOURCE_TRANSACTION_CALCULATED = "TRANSACTION_CALCULATED"
+private const val SOURCE_TRANSACTION_SMS_BALANCE = "TRANSACTION_SMS_BALANCE"
+private const val SOURCE_MANUAL = "MANUAL"
+private const val SOURCE_MANUAL_EDIT = "MANUAL_EDIT"
+private const val SOURCE_SMS_BALANCE = "SMS_BALANCE"
 
 @Dao
 interface AccountBalanceDao {
@@ -62,6 +69,98 @@ interface AccountBalanceDao {
         accountLast4: String,
         timestamp: LocalDateTime
     ): List<AccountBalanceTransactionInfo>
+
+    @Transaction
+    suspend fun insertTransactionBalance(
+        bankName: String,
+        accountLast4: String,
+        amount: BigDecimal,
+        transactionType: TransactionType,
+        explicitBalance: BigDecimal?,
+        timestamp: LocalDateTime,
+        transactionId: Long?,
+        creditLimit: BigDecimal?,
+        isCreditCard: Boolean,
+        smsSource: String?,
+        currency: String
+    ): Long {
+        val latest = getLatestBalance(bankName, accountLast4)
+        val previous = getLatestBalanceOnOrBefore(bankName, accountLast4, timestamp)
+        val accountIsCreditCard = isCreditCard || (previous?.isCreditCard ?: latest?.isCreditCard ?: false)
+        val newBalance = explicitBalance ?: calculateTransactionBalance(
+            currentBalance = previous?.balance ?: BigDecimal.ZERO,
+            amount = amount,
+            transactionType = transactionType,
+            isCreditCard = accountIsCreditCard
+        )
+
+        val balanceId = insertBalance(
+            AccountBalanceEntity(
+                bankName = bankName,
+                accountLast4 = accountLast4,
+                balance = newBalance,
+                timestamp = timestamp,
+                transactionId = transactionId,
+                creditLimit = creditLimit ?: previous?.creditLimit ?: latest?.creditLimit,
+                isCreditCard = accountIsCreditCard,
+                smsSource = smsSource?.take(500),
+                sourceType = if (explicitBalance != null) {
+                    SOURCE_TRANSACTION_SMS_BALANCE
+                } else {
+                    SOURCE_TRANSACTION_CALCULATED
+                },
+                currency = currency,
+                iconResId = previous?.iconResId ?: latest?.iconResId ?: 0,
+                iconName = previous?.iconName ?: latest?.iconName ?: "",
+                isWallet = previous?.isWallet ?: latest?.isWallet ?: false,
+                color = previous?.color ?: latest?.color ?: "#33B5E5"
+            )
+        )
+
+        recalculateBalancesAfter(bankName, accountLast4, timestamp, newBalance)
+        return balanceId
+    }
+
+    private suspend fun recalculateBalancesAfter(
+        bankName: String,
+        accountLast4: String,
+        timestamp: LocalDateTime,
+        startingBalance: BigDecimal
+    ) {
+        var runningBalance = startingBalance
+        getBalancesAfterWithTransactions(bankName, accountLast4, timestamp).forEach { row ->
+            val sourceType = row.sourceType
+            val hasExplicitBalance = row.transactionBalanceAfter != null ||
+                    sourceType == SOURCE_TRANSACTION_SMS_BALANCE ||
+                    sourceType == SOURCE_SMS_BALANCE ||
+                    sourceType == SOURCE_MANUAL ||
+                    sourceType == SOURCE_MANUAL_EDIT
+
+            if (hasExplicitBalance || row.transactionId == null) {
+                runningBalance = row.balance
+                return@forEach
+            }
+
+            val amount = row.transactionAmount
+            val transactionType = row.transactionType?.let { runCatching { TransactionType.valueOf(it) }.getOrNull() }
+            if (amount == null || transactionType == null) {
+                runningBalance = row.balance
+                return@forEach
+            }
+
+            val recalculated = calculateTransactionBalance(
+                currentBalance = runningBalance,
+                amount = amount,
+                transactionType = transactionType,
+                isCreditCard = row.isCreditCard
+            )
+
+            if (recalculated != row.balance) {
+                updateBalanceById(row.id, recalculated)
+            }
+            runningBalance = recalculated
+        }
+    }
     
     @Query("""
         SELECT * FROM account_balances 
@@ -230,3 +329,20 @@ data class AccountBalanceTransactionInfo(
     val transactionType: String?,
     val transactionBalanceAfter: BigDecimal?
 )
+
+private fun calculateTransactionBalance(
+    currentBalance: BigDecimal,
+    amount: BigDecimal,
+    transactionType: TransactionType,
+    isCreditCard: Boolean
+): BigDecimal {
+    return when {
+        isCreditCard && transactionType == TransactionType.INCOME ->
+            (currentBalance - amount).max(BigDecimal.ZERO)
+        isCreditCard -> currentBalance + amount
+        transactionType == TransactionType.INCOME -> currentBalance + amount
+        transactionType == TransactionType.EXPENSE || transactionType == TransactionType.INVESTMENT ->
+            (currentBalance - amount).max(BigDecimal.ZERO)
+        else -> currentBalance
+    }
+}

--- a/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
@@ -27,6 +27,41 @@ interface AccountBalanceDao {
         AND account_last4 LIKE '%' || :suffix
     """)
     suspend fun getAccountLast4sEndingWith(bankName: String, suffix: String): List<String>
+
+    @Query("""
+        SELECT * FROM account_balances
+        WHERE bank_name = :bankName AND account_last4 = :accountLast4
+        AND timestamp <= :timestamp
+        ORDER BY timestamp DESC, id DESC
+        LIMIT 1
+    """)
+    suspend fun getLatestBalanceOnOrBefore(
+        bankName: String,
+        accountLast4: String,
+        timestamp: LocalDateTime
+    ): AccountBalanceEntity?
+
+    @Query("""
+        SELECT
+            ab.id AS id,
+            ab.balance AS balance,
+            ab.source_type AS sourceType,
+            ab.is_credit_card AS isCreditCard,
+            ab.transaction_id AS transactionId,
+            t.amount AS transactionAmount,
+            t.transaction_type AS transactionType,
+            t.balance_after AS transactionBalanceAfter
+        FROM account_balances ab
+        LEFT JOIN transactions t ON t.id = ab.transaction_id
+        WHERE ab.bank_name = :bankName AND ab.account_last4 = :accountLast4
+        AND ab.timestamp > :timestamp
+        ORDER BY ab.timestamp ASC, ab.id ASC
+    """)
+    suspend fun getBalancesAfterWithTransactions(
+        bankName: String,
+        accountLast4: String,
+        timestamp: LocalDateTime
+    ): List<AccountBalanceTransactionInfo>
     
     @Query("""
         SELECT * FROM account_balances 
@@ -184,3 +219,14 @@ interface AccountBalanceDao {
     """)
     suspend fun getAccountByLast4(accountLast4: String): AccountBalanceEntity?
 }
+
+data class AccountBalanceTransactionInfo(
+    val id: Long,
+    val balance: BigDecimal,
+    val sourceType: String?,
+    val isCreditCard: Boolean,
+    val transactionId: Long?,
+    val transactionAmount: BigDecimal?,
+    val transactionType: String?,
+    val transactionBalanceAfter: BigDecimal?
+)

--- a/app/src/main/java/com/ritesh/cashiro/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/manager/SmsTransactionProcessor.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import com.ritesh.cashiro.BuildConfig
 import com.ritesh.parser.core.ParsedTransaction
 import com.ritesh.parser.core.bank.BankParserFactory
-import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.data.database.entity.CardType
 import com.ritesh.cashiro.data.database.entity.TransactionEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
@@ -264,7 +263,7 @@ class SmsTransactionProcessor @Inject constructor(
                     currentBalance + parsedTransaction.amount
                 }
                 existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                    val currentBalance = existingAccount.balance ?: BigDecimal.ZERO
+                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
                     (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
                 }
                 parsedTransaction.balance != null -> parsedTransaction.balance!!
@@ -289,10 +288,12 @@ class SmsTransactionProcessor @Inject constructor(
                 }
             }
 
-            val balanceEntity = AccountBalanceEntity(
+            accountBalanceRepository.insertTransactionBalance(
                 bankName = parsedTransaction.bankName,
                 accountLast4 = targetAccountLast4,
-                balance = newBalance,
+                amount = parsedTransaction.amount,
+                transactionType = parsedTransaction.type.toEntityType(),
+                explicitBalance = parsedTransaction.balance,
                 timestamp = entity.dateTime,
                 transactionId = if (rowId != -1L) rowId else null,
                 creditLimit = if (isCreditCard) {
@@ -301,12 +302,10 @@ class SmsTransactionProcessor @Inject constructor(
                     existingAccount?.creditLimit
                 },
                 isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
-                smsSource = parsedTransaction.smsBody.take(500),
-                sourceType = "TRANSACTION",
+                smsSource = parsedTransaction.smsBody,
                 currency = parsedTransaction.currency
             )
 
-            accountBalanceRepository.insertBalance(balanceEntity)
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "Saved balance update for ${parsedTransaction.bankName} **$targetAccountLast4")
             }

--- a/app/src/main/java/com/ritesh/cashiro/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/manager/SmsTransactionProcessor.kt
@@ -198,25 +198,27 @@ class SmsTransactionProcessor @Inject constructor(
         entity: TransactionEntity,
         rowId: Long
     ) {
-        val parsedAccountLast4 = parsedTransaction.accountLast4 ?: return
+        val parsedAccountLast4 = parsedTransaction.accountLast4?.takeIf { it.isNotBlank() }
+        val resolvedAccountLast4 = entity.accountNumber?.takeIf { it.isNotBlank() }
+        if (parsedAccountLast4 == null && resolvedAccountLast4 == null) return
 
         val isFromCard = parsedTransaction.isFromCard
 
         val targetAccountLast4: String? = if (isFromCard) {
-            var card = parsedTransaction.accountLast4?.let {
+            var card = parsedAccountLast4?.let {
                 cardRepository.getCard(parsedTransaction.bankName, it)
             }
 
             if (card == null) {
                 val isCredit = (parsedTransaction.type.toEntityType() == TransactionType.CREDIT)
-                parsedTransaction.accountLast4?.let { accountLast4 ->
+                parsedAccountLast4?.let { accountLast4 ->
                     cardRepository.findOrCreateCard(
                         cardLast4 = accountLast4,
                         bankName = parsedTransaction.bankName,
                         isCredit = isCredit
                     )
                 }
-                card = parsedTransaction.accountLast4?.let {
+                card = parsedAccountLast4?.let {
                     cardRepository.getCard(parsedTransaction.bankName, it)
                 }
             }
@@ -229,7 +231,7 @@ class SmsTransactionProcessor @Inject constructor(
                 cardRepository.updateCardBalance(
                     cardId = card.id,
                     balance = parsedTransaction.balance,
-                    source = parsedTransaction.smsBody.take(200),
+                    source = sanitizeSmsSource(parsedTransaction).take(200),
                     date = LocalDateTime.ofInstant(
                         Instant.ofEpochMilli(parsedTransaction.timestamp),
                         ZoneId.systemDefault()
@@ -237,13 +239,13 @@ class SmsTransactionProcessor @Inject constructor(
                 )
 
                 when {
-                    card.cardType == CardType.CREDIT -> parsedTransaction.accountLast4
+                    card.cardType == CardType.CREDIT -> parsedAccountLast4
                     card.cardType == CardType.DEBIT && card.accountLast4 != null -> card.accountLast4
                     else -> null
                 }
             }
         } else {
-            entity.accountNumber?.takeIf { it.isNotBlank() } ?: parsedAccountLast4
+            resolvedAccountLast4 ?: parsedAccountLast4
         }
 
         if (targetAccountLast4 != null) {
@@ -258,13 +260,15 @@ class SmsTransactionProcessor @Inject constructor(
             )
 
             val newBalance = when {
+                existingAccount != null &&
+                    existingAccount.isCreditCard &&
+                    parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
+                    val currentBalance = existingAccount.balance
+                    (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
+                }
                 isCreditCard -> {
                     val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
                     currentBalance + parsedTransaction.amount
-                }
-                existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
-                    (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
                 }
                 parsedTransaction.balance != null -> parsedTransaction.balance!!
                 else -> {
@@ -302,13 +306,17 @@ class SmsTransactionProcessor @Inject constructor(
                     existingAccount?.creditLimit
                 },
                 isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
-                smsSource = parsedTransaction.smsBody,
+                smsSource = sanitizeSmsSource(parsedTransaction),
                 currency = parsedTransaction.currency
             )
 
             if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Saved balance update for ${parsedTransaction.bankName} **$targetAccountLast4")
+                Log.d(TAG, "Saved balance update from SMS transaction")
             }
         }
+    }
+
+    private fun sanitizeSmsSource(parsedTransaction: ParsedTransaction): String {
+        return "SMS_TRANSACTION:${parsedTransaction.type}:${parsedTransaction.currency}"
     }
 }

--- a/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
@@ -19,14 +19,6 @@ class AccountBalanceRepository @Inject constructor(
     private val accountBalanceDao: AccountBalanceDao,
     @ApplicationContext private val context: Context
 ) {
-    private companion object {
-        const val SOURCE_TRANSACTION_CALCULATED = "TRANSACTION_CALCULATED"
-        const val SOURCE_TRANSACTION_SMS_BALANCE = "TRANSACTION_SMS_BALANCE"
-        const val SOURCE_MANUAL = "MANUAL"
-        const val SOURCE_MANUAL_EDIT = "MANUAL_EDIT"
-        const val SOURCE_SMS_BALANCE = "SMS_BALANCE"
-    }
-
     suspend fun insertBalance(balance: AccountBalanceEntity): Long {
         val balanceWithIconName = if (balance.iconName.isEmpty() && balance.iconResId != 0) {
             balance.copy(iconName = IconResolutionUtils.resIdToName(context, balance.iconResId))
@@ -151,98 +143,19 @@ class AccountBalanceRepository @Inject constructor(
         smsSource: String?,
         currency: String
     ): Long {
-        val latest = getLatestBalance(bankName, accountLast4)
-        val previous = accountBalanceDao.getLatestBalanceOnOrBefore(bankName, accountLast4, timestamp)
-        val accountIsCreditCard = isCreditCard || (previous?.isCreditCard ?: latest?.isCreditCard ?: false)
-        val newBalance = explicitBalance ?: calculateBalance(
-            currentBalance = previous?.balance ?: BigDecimal.ZERO,
-            amount = amount,
-            transactionType = transactionType,
-            isCreditCard = accountIsCreditCard
-        )
-
-        val balanceEntity = AccountBalanceEntity(
+        return accountBalanceDao.insertTransactionBalance(
             bankName = bankName,
             accountLast4 = accountLast4,
-            balance = newBalance,
+            amount = amount,
+            transactionType = transactionType,
+            explicitBalance = explicitBalance,
             timestamp = timestamp,
             transactionId = transactionId,
-            creditLimit = creditLimit ?: previous?.creditLimit ?: latest?.creditLimit,
-            isCreditCard = accountIsCreditCard,
-            smsSource = smsSource?.take(500),
-            sourceType = if (explicitBalance != null) {
-                SOURCE_TRANSACTION_SMS_BALANCE
-            } else {
-                SOURCE_TRANSACTION_CALCULATED
-            },
-            currency = currency,
-            iconResId = previous?.iconResId ?: latest?.iconResId ?: 0,
-            iconName = previous?.iconName ?: latest?.iconName ?: "",
-            isWallet = previous?.isWallet ?: latest?.isWallet ?: false,
-            color = previous?.color ?: latest?.color ?: "#33B5E5"
+            creditLimit = creditLimit,
+            isCreditCard = isCreditCard,
+            smsSource = smsSource,
+            currency = currency
         )
-
-        val balanceId = insertBalance(balanceEntity)
-        recalculateBalancesAfter(bankName, accountLast4, timestamp, newBalance)
-        return balanceId
-    }
-
-    private suspend fun recalculateBalancesAfter(
-        bankName: String,
-        accountLast4: String,
-        timestamp: LocalDateTime,
-        startingBalance: BigDecimal
-    ) {
-        var runningBalance = startingBalance
-        accountBalanceDao.getBalancesAfterWithTransactions(bankName, accountLast4, timestamp).forEach { row ->
-            val sourceType = row.sourceType
-            val hasExplicitBalance = row.transactionBalanceAfter != null ||
-                    sourceType == SOURCE_TRANSACTION_SMS_BALANCE ||
-                    sourceType == SOURCE_SMS_BALANCE ||
-                    sourceType == SOURCE_MANUAL ||
-                    sourceType == SOURCE_MANUAL_EDIT
-
-            if (hasExplicitBalance || row.transactionId == null) {
-                runningBalance = row.balance
-                return@forEach
-            }
-
-            val amount = row.transactionAmount
-            val transactionType = row.transactionType?.let { runCatching { TransactionType.valueOf(it) }.getOrNull() }
-            if (amount == null || transactionType == null) {
-                runningBalance = row.balance
-                return@forEach
-            }
-
-            val recalculated = calculateBalance(
-                currentBalance = runningBalance,
-                amount = amount,
-                transactionType = transactionType,
-                isCreditCard = row.isCreditCard
-            )
-
-            if (recalculated != row.balance) {
-                accountBalanceDao.updateBalanceById(row.id, recalculated)
-            }
-            runningBalance = recalculated
-        }
-    }
-
-    private fun calculateBalance(
-        currentBalance: BigDecimal,
-        amount: BigDecimal,
-        transactionType: TransactionType,
-        isCreditCard: Boolean
-    ): BigDecimal {
-        return when {
-            isCreditCard && transactionType == TransactionType.INCOME ->
-                (currentBalance - amount).max(BigDecimal.ZERO)
-            isCreditCard -> currentBalance + amount
-            transactionType == TransactionType.INCOME -> currentBalance + amount
-            transactionType == TransactionType.EXPENSE || transactionType == TransactionType.INVESTMENT ->
-                (currentBalance - amount).max(BigDecimal.ZERO)
-            else -> currentBalance
-        }
     }
 
     suspend fun insertBalanceUpdate(

--- a/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
@@ -235,8 +235,8 @@ class AccountBalanceRepository @Inject constructor(
         isCreditCard: Boolean
     ): BigDecimal {
         return when {
-            // Credit card payments reduce debt before this generic recalculation path.
-            isCreditCard && transactionType == TransactionType.INCOME -> currentBalance
+            isCreditCard && transactionType == TransactionType.INCOME ->
+                (currentBalance - amount).max(BigDecimal.ZERO)
             isCreditCard -> currentBalance + amount
             transactionType == TransactionType.INCOME -> currentBalance + amount
             transactionType == TransactionType.EXPENSE || transactionType == TransactionType.INVESTMENT ->

--- a/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/repository/AccountBalanceRepository.kt
@@ -3,6 +3,7 @@ package com.ritesh.cashiro.data.repository
 import android.content.Context
 import com.ritesh.cashiro.data.database.dao.AccountBalanceDao
 import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
+import com.ritesh.cashiro.data.database.entity.TransactionType
 import kotlinx.coroutines.flow.Flow
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -18,6 +19,13 @@ class AccountBalanceRepository @Inject constructor(
     private val accountBalanceDao: AccountBalanceDao,
     @ApplicationContext private val context: Context
 ) {
+    private companion object {
+        const val SOURCE_TRANSACTION_CALCULATED = "TRANSACTION_CALCULATED"
+        const val SOURCE_TRANSACTION_SMS_BALANCE = "TRANSACTION_SMS_BALANCE"
+        const val SOURCE_MANUAL = "MANUAL"
+        const val SOURCE_MANUAL_EDIT = "MANUAL_EDIT"
+        const val SOURCE_SMS_BALANCE = "SMS_BALANCE"
+    }
 
     suspend fun insertBalance(balance: AccountBalanceEntity): Long {
         val balanceWithIconName = if (balance.iconName.isEmpty() && balance.iconResId != 0) {
@@ -127,6 +135,113 @@ class AccountBalanceRepository @Inject constructor(
                 color = latest?.color ?: "#33B5E5"
             )
             insertBalance(balanceEntity)
+        }
+    }
+
+    suspend fun insertTransactionBalance(
+        bankName: String,
+        accountLast4: String,
+        amount: BigDecimal,
+        transactionType: TransactionType,
+        explicitBalance: BigDecimal?,
+        timestamp: LocalDateTime,
+        transactionId: Long?,
+        creditLimit: BigDecimal?,
+        isCreditCard: Boolean,
+        smsSource: String?,
+        currency: String
+    ): Long {
+        val latest = getLatestBalance(bankName, accountLast4)
+        val previous = accountBalanceDao.getLatestBalanceOnOrBefore(bankName, accountLast4, timestamp)
+        val accountIsCreditCard = isCreditCard || (previous?.isCreditCard ?: latest?.isCreditCard ?: false)
+        val newBalance = explicitBalance ?: calculateBalance(
+            currentBalance = previous?.balance ?: BigDecimal.ZERO,
+            amount = amount,
+            transactionType = transactionType,
+            isCreditCard = accountIsCreditCard
+        )
+
+        val balanceEntity = AccountBalanceEntity(
+            bankName = bankName,
+            accountLast4 = accountLast4,
+            balance = newBalance,
+            timestamp = timestamp,
+            transactionId = transactionId,
+            creditLimit = creditLimit ?: previous?.creditLimit ?: latest?.creditLimit,
+            isCreditCard = accountIsCreditCard,
+            smsSource = smsSource?.take(500),
+            sourceType = if (explicitBalance != null) {
+                SOURCE_TRANSACTION_SMS_BALANCE
+            } else {
+                SOURCE_TRANSACTION_CALCULATED
+            },
+            currency = currency,
+            iconResId = previous?.iconResId ?: latest?.iconResId ?: 0,
+            iconName = previous?.iconName ?: latest?.iconName ?: "",
+            isWallet = previous?.isWallet ?: latest?.isWallet ?: false,
+            color = previous?.color ?: latest?.color ?: "#33B5E5"
+        )
+
+        val balanceId = insertBalance(balanceEntity)
+        recalculateBalancesAfter(bankName, accountLast4, timestamp, newBalance)
+        return balanceId
+    }
+
+    private suspend fun recalculateBalancesAfter(
+        bankName: String,
+        accountLast4: String,
+        timestamp: LocalDateTime,
+        startingBalance: BigDecimal
+    ) {
+        var runningBalance = startingBalance
+        accountBalanceDao.getBalancesAfterWithTransactions(bankName, accountLast4, timestamp).forEach { row ->
+            val sourceType = row.sourceType
+            val hasExplicitBalance = row.transactionBalanceAfter != null ||
+                    sourceType == SOURCE_TRANSACTION_SMS_BALANCE ||
+                    sourceType == SOURCE_SMS_BALANCE ||
+                    sourceType == SOURCE_MANUAL ||
+                    sourceType == SOURCE_MANUAL_EDIT
+
+            if (hasExplicitBalance || row.transactionId == null) {
+                runningBalance = row.balance
+                return@forEach
+            }
+
+            val amount = row.transactionAmount
+            val transactionType = row.transactionType?.let { runCatching { TransactionType.valueOf(it) }.getOrNull() }
+            if (amount == null || transactionType == null) {
+                runningBalance = row.balance
+                return@forEach
+            }
+
+            val recalculated = calculateBalance(
+                currentBalance = runningBalance,
+                amount = amount,
+                transactionType = transactionType,
+                isCreditCard = row.isCreditCard
+            )
+
+            if (recalculated != row.balance) {
+                accountBalanceDao.updateBalanceById(row.id, recalculated)
+            }
+            runningBalance = recalculated
+        }
+    }
+
+    private fun calculateBalance(
+        currentBalance: BigDecimal,
+        amount: BigDecimal,
+        transactionType: TransactionType,
+        isCreditCard: Boolean
+    ): BigDecimal {
+        return when {
+            // Credit card payments reduce debt before this generic recalculation path.
+            isCreditCard && transactionType == TransactionType.INCOME -> currentBalance
+            isCreditCard -> currentBalance + amount
+            transactionType == TransactionType.INCOME -> currentBalance + amount
+            transactionType == TransactionType.EXPENSE || transactionType == TransactionType.INVESTMENT ->
+                (currentBalance - amount).max(BigDecimal.ZERO)
+            else -> currentBalance
         }
     }
 

--- a/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
@@ -17,7 +17,6 @@ import com.ritesh.parser.core.bank.IndianBankParser
 import com.ritesh.parser.core.bank.SBIBankParser
 import com.ritesh.parser.core.bank.IndusIndBankParser
 import com.ritesh.parser.core.SmsFilter
-import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
 import com.ritesh.cashiro.data.database.entity.UnrecognizedSmsEntity
 import com.ritesh.cashiro.data.mapper.toEntity
@@ -1252,7 +1251,7 @@ private suspend fun processBalanceUpdate(
                 }
 
                 existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                    val currentBalance = existingAccount.balance ?: BigDecimal.ZERO
+                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
                     (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
                 }
 
@@ -1318,11 +1317,12 @@ private suspend fun processBalanceUpdate(
             }
 
             if (shouldSaveBalance) {
-                // Create the balance entity using the target account
-                val balanceEntity = AccountBalanceEntity(
+                accountBalanceRepository.insertTransactionBalance(
                     bankName = parsedTransaction.bankName,
                     accountLast4 = targetAccountLast4,
-                    balance = newBalance,
+                    amount = parsedTransaction.amount,
+                    transactionType = parsedTransaction.type.toEntityType(),
+                    explicitBalance = parsedTransaction.balance,
                     timestamp = entity.dateTime,
                     transactionId = if (rowId != -1L) rowId else null,
                     creditLimit = if (isCreditCard) {
@@ -1331,12 +1331,9 @@ private suspend fun processBalanceUpdate(
                         existingAccount?.creditLimit
                     },
                     isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
-                    smsSource = parsedTransaction.smsBody.take(500),  // Store SMS snippet
-                    sourceType = "TRANSACTION",
+                    smsSource = parsedTransaction.smsBody,
                     currency = parsedTransaction.currency
                 )
-
-                accountBalanceRepository.insertBalance(balanceEntity)
 
                 if (BuildConfig.DEBUG) {
                     val logMsg = if (parsedTransaction.creditLimit != null) {

--- a/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
@@ -1250,8 +1250,10 @@ private suspend fun processBalanceUpdate(
                     currentBalance + parsedTransaction.amount
                 }
 
-                existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
+                existingAccount != null &&
+                    existingAccount.isCreditCard &&
+                    parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
+                    val currentBalance = existingAccount.balance
                     (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
                 }
 

--- a/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/OptimizedSmsReaderWorker.kt
@@ -1145,16 +1145,14 @@ private suspend fun processBalanceUpdate(
     if (parsedAccountLast4 != null) {
         // Determine if this transaction is from a card based on the message pattern
         val isFromCard = parsedTransaction.isFromCard
+        val sanitizedSmsSource = "SMS_TRANSACTION:${parsedTransaction.type}:${parsedTransaction.currency}"
 
         if (BuildConfig.DEBUG) {
             Log.d(
                 TAG, """
                     Processing transaction:
-                    - Bank: ${parsedTransaction.bankName}
-                    - Number: **${parsedTransaction.accountLast4}
                     - Is From Card: $isFromCard
                     - Transaction Type: ${parsedTransaction.type}
-                    - SMS Body (first 200 chars): ${parsedTransaction.smsBody.take(200)}
                 """.trimIndent()
             )
         }
@@ -1195,7 +1193,7 @@ private suspend fun processBalanceUpdate(
             cardRepository.updateCardBalance(
                 cardId = card.id,
                 balance = parsedTransaction.balance,  // Can be null
-                source = parsedTransaction.smsBody.take(200),  // Always save source
+                source = sanitizedSmsSource.take(200),
                 date = LocalDateTime.ofInstant(
                     Instant.ofEpochMilli(parsedTransaction.timestamp),
                     ZoneId.systemDefault()
@@ -1245,16 +1243,16 @@ private suspend fun processBalanceUpdate(
             )
 
             val newBalance = when {
-                isCreditCard -> {
-                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
-                    currentBalance + parsedTransaction.amount
-                }
-
                 existingAccount != null &&
                     existingAccount.isCreditCard &&
                     parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
                     val currentBalance = existingAccount.balance
                     (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
+                }
+
+                isCreditCard -> {
+                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
+                    currentBalance + parsedTransaction.amount
                 }
 
                 parsedTransaction.balance != null -> {
@@ -1294,9 +1292,6 @@ private suspend fun processBalanceUpdate(
                     TAG, """
                         Saving account balance:
                         - SMS Timestamp: ${parsedTransaction.timestamp} (${java.time.Instant.ofEpochMilli(parsedTransaction.timestamp)})
-                        - Bank: ${parsedTransaction.bankName}
-                        - Original: **${parsedTransaction.accountLast4}
-                        - Target Account: **$targetAccountLast4
                         - Is Card Transaction: ${parsedTransaction.isFromCard}
                         - Is Credit Card: $isCreditCard
                         - Transaction Type: ${parsedTransaction.type.toEntityType()}
@@ -1333,7 +1328,7 @@ private suspend fun processBalanceUpdate(
                         existingAccount?.creditLimit
                     },
                     isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
-                    smsSource = parsedTransaction.smsBody,
+                    smsSource = sanitizedSmsSource,
                     currency = parsedTransaction.currency
                 )
 
@@ -1343,15 +1338,15 @@ private suspend fun processBalanceUpdate(
                             CurrencyFormatter.formatCurrency(
                                 parsedTransaction.creditLimit!!
                             )
-                        }) for ${parsedTransaction.bankName} **$targetAccountLast4"
+                        }) from SMS transaction"
                     } else {
-                        "Saved balance update for ${parsedTransaction.bankName} **$targetAccountLast4"
+                        "Saved balance update from SMS transaction"
                     }
                     Log.d(TAG, logMsg)
                 }
             } else {
                 if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "Skipped saving balance: ${parsedTransaction.bankName} **$targetAccountLast4")
+                    Log.d(TAG, "Skipped saving balance for SMS transaction")
                 }
             }
         } else {

--- a/app/src/main/java/com/ritesh/cashiro/worker/SmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/SmsReaderWorker.kt
@@ -368,15 +368,13 @@ class SmsReaderWorker @AssistedInject constructor(
                                 
                                 // Determine if this transaction is from a card based on the message pattern
                                 val isFromCard = parsedTransaction.isFromCard
+                                val sanitizedSmsSource = "SMS_TRANSACTION:${parsedTransaction.type}:${parsedTransaction.currency}"
                                 
                                 if (BuildConfig.DEBUG) {
                                     Log.d(TAG, """
                                         Processing transaction:
-                                        - Bank: ${parsedTransaction.bankName}
-                                        - Number: **${parsedTransaction.accountLast4}
                                         - Is From Card: $isFromCard
                                         - Transaction Type: ${parsedTransaction.type}
-                                        - SMS Body (first 200 chars): ${parsedTransaction.smsBody.take(200)}
                                     """.trimIndent())
                                 }
                                 
@@ -417,7 +415,7 @@ class SmsReaderWorker @AssistedInject constructor(
                                     cardRepository.updateCardBalance(
                                         cardId = card.id,
                                         balance = parsedTransaction.balance,  // Can be null
-                                        source = parsedTransaction.smsBody.take(200),  // Always save source
+                                        source = sanitizedSmsSource.take(200),
                                         date = LocalDateTime.ofInstant(
                                             Instant.ofEpochMilli(parsedTransaction.timestamp),
                                             ZoneId.systemDefault()
@@ -466,12 +464,6 @@ class SmsReaderWorker @AssistedInject constructor(
                                     
                                     // Calculate new balance based on transaction
                                     val newBalance = when {
-                                        // For credit cards: spending increases balance (debt), payments decrease it
-                                        isCreditCard -> {
-                                            val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
-                                            // Credit card transaction (CREDIT type) = spending, add to outstanding
-                                            currentBalance + parsedTransaction.amount
-                                        }
                                         // Check if this is a payment TO a credit card (reducing debt)
                                         existingAccount != null &&
                                             existingAccount.isCreditCard &&
@@ -479,6 +471,12 @@ class SmsReaderWorker @AssistedInject constructor(
                                             val currentBalance = existingAccount.balance
                                             // Payment to credit card, reduce outstanding
                                             (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
+                                        }
+                                        // For credit cards: spending increases balance (debt), payments decrease it
+                                        isCreditCard -> {
+                                            val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
+                                            // Credit card transaction (CREDIT type) = spending, add to outstanding
+                                            currentBalance + parsedTransaction.amount
                                         }
                                         // For regular accounts, use balance from SMS if available
                                         parsedTransaction.balance != null -> {
@@ -493,9 +491,6 @@ class SmsReaderWorker @AssistedInject constructor(
                                     if (BuildConfig.DEBUG) {
                                         Log.d(TAG, """
                                             Saving account balance:
-                                            - Bank: ${parsedTransaction.bankName}
-                                            - Original: **${parsedTransaction.accountLast4}
-                                            - Target Account: **$targetAccountLast4
                                             - Is Card Transaction: ${parsedTransaction.isFromCard}
                                             - Is Credit Card: $isCreditCard
                                             - Transaction Amount: ${parsedTransaction.amount}
@@ -529,21 +524,21 @@ class SmsReaderWorker @AssistedInject constructor(
                                                 existingAccount?.creditLimit
                                             },
                                             isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
-                                            smsSource = parsedTransaction.smsBody,
+                                            smsSource = sanitizedSmsSource,
                                             currency = parsedTransaction.currency
                                         )
                                         
                                         if (BuildConfig.DEBUG) {
                                             val logMsg = if (parsedTransaction.creditLimit != null) {
-                                                "Saved balance/credit limit (${CurrencyFormatter.formatCurrency(parsedTransaction.creditLimit!!)}) for ${parsedTransaction.bankName} **$targetAccountLast4"
+                                                "Saved balance/credit limit (${CurrencyFormatter.formatCurrency(parsedTransaction.creditLimit!!)}) from SMS transaction"
                                             } else {
-                                                "Saved balance update for ${parsedTransaction.bankName} **$targetAccountLast4"
+                                                "Saved balance update from SMS transaction"
                                             }
                                             Log.d(TAG, logMsg)
                                         }
                                     } else {
                                         if (BuildConfig.DEBUG) {
-                                            Log.d(TAG, "Skipped saving balance: ${parsedTransaction.bankName} **$targetAccountLast4")
+                                            Log.d(TAG, "Skipped saving balance for SMS transaction")
                                         }
                                     }
                                 } else {

--- a/app/src/main/java/com/ritesh/cashiro/worker/SmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/SmsReaderWorker.kt
@@ -25,7 +25,6 @@ import com.ritesh.cashiro.data.repository.TransactionRepository
 import com.ritesh.cashiro.data.repository.UnrecognizedSmsRepository
 import com.ritesh.cashiro.domain.repository.RuleRepository
 import com.ritesh.cashiro.domain.service.RuleEngine
-import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
 import com.ritesh.cashiro.data.database.entity.UnrecognizedSmsEntity
 import com.ritesh.cashiro.data.preferences.UserPreferencesRepository
@@ -475,7 +474,7 @@ class SmsReaderWorker @AssistedInject constructor(
                                         }
                                         // Check if this is a payment TO a credit card (reducing debt)
                                         existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                                            val currentBalance = existingAccount.balance ?: BigDecimal.ZERO
+                                            val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
                                             // Payment to credit card, reduce outstanding
                                             (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
                                         }
@@ -514,11 +513,12 @@ class SmsReaderWorker @AssistedInject constructor(
                                     }
                                     
                                     if (shouldSaveBalance) {
-                                        // Create the balance entity using the target account
-                                        val balanceEntity = AccountBalanceEntity(
+                                        accountBalanceRepository.insertTransactionBalance(
                                             bankName = parsedTransaction.bankName,
                                             accountLast4 = targetAccountLast4,
-                                            balance = newBalance,
+                                            amount = parsedTransaction.amount,
+                                            transactionType = parsedTransaction.type.toEntityType(),
+                                            explicitBalance = parsedTransaction.balance,
                                             timestamp = finalEntity.dateTime,
                                             transactionId = if (rowId != -1L) rowId else null,
                                             creditLimit = if (isCreditCard) {
@@ -527,12 +527,9 @@ class SmsReaderWorker @AssistedInject constructor(
                                                 existingAccount?.creditLimit
                                             },
                                             isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
-                                            smsSource = parsedTransaction.smsBody.take(500),  // Store SMS snippet
-                                            sourceType = "TRANSACTION",
+                                            smsSource = parsedTransaction.smsBody,
                                             currency = parsedTransaction.currency
                                         )
-                                        
-                                        accountBalanceRepository.insertBalance(balanceEntity)
                                         
                                         if (BuildConfig.DEBUG) {
                                             val logMsg = if (parsedTransaction.creditLimit != null) {

--- a/app/src/main/java/com/ritesh/cashiro/worker/SmsReaderWorker.kt
+++ b/app/src/main/java/com/ritesh/cashiro/worker/SmsReaderWorker.kt
@@ -473,8 +473,10 @@ class SmsReaderWorker @AssistedInject constructor(
                                             currentBalance + parsedTransaction.amount
                                         }
                                         // Check if this is a payment TO a credit card (reducing debt)
-                                        existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                                            val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
+                                        existingAccount != null &&
+                                            existingAccount.isCreditCard &&
+                                            parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
+                                            val currentBalance = existingAccount.balance
                                             // Payment to credit card, reduce outstanding
                                             (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
                                         }

--- a/app/src/test/java/com/ritesh/cashiro/data/repository/AccountBalanceRepositoryTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/data/repository/AccountBalanceRepositoryTest.kt
@@ -218,6 +218,48 @@ class AccountBalanceRepositoryTest {
         assertEquals(0, dao.suffixLookupCount)
     }
 
+    @Test
+    fun insertTransactionBalanceReducesCreditCardBalanceForIncomePayment() = runTest {
+        val transactionTime = LocalDateTime.of(2026, 5, 23, 20, 35)
+        val dao = FakeAccountBalanceDao(
+            latestBalances = mutableMapOf(
+                accountKey("Test Bank", "1234") to balance(
+                    id = 1,
+                    bankName = "Test Bank",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("100.00"),
+                    timestamp = transactionTime.minusMinutes(5),
+                    isCreditCard = true
+                )
+            ),
+            balanceAtOrBefore = balance(
+                id = 1,
+                bankName = "Test Bank",
+                accountLast4 = "1234",
+                balance = BigDecimal("100.00"),
+                timestamp = transactionTime.minusMinutes(5),
+                isCreditCard = true
+            )
+        )
+        val repository = AccountBalanceRepository(dao, ContextWrapper(null))
+
+        repository.insertTransactionBalance(
+            bankName = "Test Bank",
+            accountLast4 = "1234",
+            amount = BigDecimal("30.00"),
+            transactionType = TransactionType.INCOME,
+            explicitBalance = null,
+            timestamp = transactionTime,
+            transactionId = 11,
+            creditLimit = null,
+            isCreditCard = true,
+            smsSource = "payment alert",
+            currency = "INR"
+        )
+
+        assertEquals(BigDecimal("70.00"), dao.insertedBalances.single().balance)
+    }
+
     private class FakeAccountBalanceDao(
         private val latestBalances: MutableMap<String, AccountBalanceEntity> = mutableMapOf(),
         private val balanceAtOrBefore: AccountBalanceEntity? = null,
@@ -321,13 +363,15 @@ class AccountBalanceRepositoryTest {
             bankName: String,
             accountLast4: String,
             balance: BigDecimal,
-            timestamp: LocalDateTime
+            timestamp: LocalDateTime,
+            isCreditCard: Boolean = false
         ) = AccountBalanceEntity(
             id = id,
             bankName = bankName,
             accountLast4 = accountLast4,
             balance = balance,
-            timestamp = timestamp
+            timestamp = timestamp,
+            isCreditCard = isCreditCard
         )
     }
 }

--- a/app/src/test/java/com/ritesh/cashiro/data/repository/AccountBalanceRepositoryTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/data/repository/AccountBalanceRepositoryTest.kt
@@ -2,7 +2,9 @@ package com.ritesh.cashiro.data.repository
 
 import android.content.ContextWrapper
 import com.ritesh.cashiro.data.database.dao.AccountBalanceDao
+import com.ritesh.cashiro.data.database.dao.AccountBalanceTransactionInfo
 import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
+import com.ritesh.cashiro.data.database.entity.TransactionType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -12,6 +14,163 @@ import java.time.LocalDateTime
 import kotlin.test.assertEquals
 
 class AccountBalanceRepositoryTest {
+
+    @Test
+    fun insertTransactionBalanceCalculatesFromBalanceAtTransactionTimeAndRecalculatesLaterCalculatedRows() = runTest {
+        val transactionTime = LocalDateTime.of(2026, 5, 23, 20, 35)
+        val dao = FakeAccountBalanceDao(
+            latestBalances = mutableMapOf(
+                accountKey("Test Bank", "1234") to balance(
+                    id = 1,
+                    bankName = "Test Bank",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("100.00"),
+                    timestamp = transactionTime.minusMinutes(5)
+                )
+            ),
+            balanceAtOrBefore = balance(
+                id = 1,
+                bankName = "Test Bank",
+                accountLast4 = "1234",
+                balance = BigDecimal("100.00"),
+                timestamp = transactionTime.minusMinutes(5)
+            ),
+            balancesAfter = listOf(
+                AccountBalanceTransactionInfo(
+                    id = 2,
+                    balance = BigDecimal("90.00"),
+                    sourceType = "TRANSACTION_CALCULATED",
+                    isCreditCard = false,
+                    transactionId = 22,
+                    transactionAmount = BigDecimal("10.00"),
+                    transactionType = TransactionType.EXPENSE.name,
+                    transactionBalanceAfter = null
+                )
+            )
+        )
+        val repository = AccountBalanceRepository(dao, ContextWrapper(null))
+
+        repository.insertTransactionBalance(
+            bankName = "Test Bank",
+            accountLast4 = "1234",
+            amount = BigDecimal("50.00"),
+            transactionType = TransactionType.INCOME,
+            explicitBalance = null,
+            timestamp = transactionTime,
+            transactionId = 11,
+            creditLimit = null,
+            isCreditCard = false,
+            smsSource = "credited alert",
+            currency = "INR"
+        )
+
+        assertEquals(BigDecimal("150.00"), dao.insertedBalances.single().balance)
+        assertEquals(BigDecimal("140.00"), dao.updatedBalances[2])
+    }
+
+    @Test
+    fun insertTransactionBalanceDoesNotRecalculateAfterExplicitBalanceBoundary() = runTest {
+        val transactionTime = LocalDateTime.of(2026, 5, 23, 20, 35)
+        val dao = FakeAccountBalanceDao(
+            latestBalances = mutableMapOf(
+                accountKey("Test Bank", "1234") to balance(
+                    id = 1,
+                    bankName = "Test Bank",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("100.00"),
+                    timestamp = transactionTime.minusMinutes(5)
+                )
+            ),
+            balanceAtOrBefore = balance(
+                id = 1,
+                bankName = "Test Bank",
+                accountLast4 = "1234",
+                balance = BigDecimal("100.00"),
+                timestamp = transactionTime.minusMinutes(5)
+            ),
+            balancesAfter = listOf(
+                AccountBalanceTransactionInfo(
+                    id = 2,
+                    balance = BigDecimal("200.00"),
+                    sourceType = "TRANSACTION_SMS_BALANCE",
+                    isCreditCard = false,
+                    transactionId = 22,
+                    transactionAmount = BigDecimal("10.00"),
+                    transactionType = TransactionType.EXPENSE.name,
+                    transactionBalanceAfter = BigDecimal("200.00")
+                )
+            )
+        )
+        val repository = AccountBalanceRepository(dao, ContextWrapper(null))
+
+        repository.insertTransactionBalance(
+            bankName = "Test Bank",
+            accountLast4 = "1234",
+            amount = BigDecimal("50.00"),
+            transactionType = TransactionType.INCOME,
+            explicitBalance = null,
+            timestamp = transactionTime,
+            transactionId = 11,
+            creditLimit = null,
+            isCreditCard = false,
+            smsSource = "credited alert",
+            currency = "INR"
+        )
+
+        assertEquals(emptyMap(), dao.updatedBalances)
+    }
+
+    @Test
+    fun insertTransactionBalanceDoesNotRecalculateAfterManualBalanceBoundary() = runTest {
+        val transactionTime = LocalDateTime.of(2026, 5, 23, 20, 35)
+        val dao = FakeAccountBalanceDao(
+            latestBalances = mutableMapOf(
+                accountKey("Test Bank", "1234") to balance(
+                    id = 1,
+                    bankName = "Test Bank",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("100.00"),
+                    timestamp = transactionTime.minusMinutes(5)
+                )
+            ),
+            balanceAtOrBefore = balance(
+                id = 1,
+                bankName = "Test Bank",
+                accountLast4 = "1234",
+                balance = BigDecimal("100.00"),
+                timestamp = transactionTime.minusMinutes(5)
+            ),
+            balancesAfter = listOf(
+                AccountBalanceTransactionInfo(
+                    id = 2,
+                    balance = BigDecimal("200.00"),
+                    sourceType = "MANUAL",
+                    isCreditCard = false,
+                    transactionId = 22,
+                    transactionAmount = BigDecimal("10.00"),
+                    transactionType = TransactionType.EXPENSE.name,
+                    transactionBalanceAfter = null
+                )
+            )
+        )
+        val repository = AccountBalanceRepository(dao, ContextWrapper(null))
+
+        repository.insertTransactionBalance(
+            bankName = "Test Bank",
+            accountLast4 = "1234",
+            amount = BigDecimal("50.00"),
+            transactionType = TransactionType.INCOME,
+            explicitBalance = null,
+            timestamp = transactionTime,
+            transactionId = 11,
+            creditLimit = null,
+            isCreditCard = false,
+            smsSource = "credited alert",
+            currency = "INR"
+        )
+
+        assertEquals(emptyMap(), dao.updatedBalances)
+    }
 
     @Test
     fun resolveAccountLast4ExpandsUniqueSameBankSuffix() = runTest {
@@ -60,27 +219,52 @@ class AccountBalanceRepositoryTest {
     }
 
     private class FakeAccountBalanceDao(
+        private val latestBalances: MutableMap<String, AccountBalanceEntity> = mutableMapOf(),
+        private val balanceAtOrBefore: AccountBalanceEntity? = null,
+        private val balancesAfter: List<AccountBalanceTransactionInfo> = emptyList(),
         private val suffixMatches: Map<String, Map<String, List<String>>> = emptyMap()
     ) : AccountBalanceDao {
+        val insertedBalances = mutableListOf<AccountBalanceEntity>()
+        val updatedBalances = mutableMapOf<Long, BigDecimal>()
         var suffixLookupCount = 0
 
-        override suspend fun insertBalance(balance: AccountBalanceEntity): Long = 1
+        override suspend fun insertBalance(balance: AccountBalanceEntity): Long {
+            val id = (insertedBalances.size + 100).toLong()
+            val inserted = balance.copy(id = id)
+            insertedBalances += inserted
+            latestBalances[accountKey(balance.bankName, balance.accountLast4)] = inserted
+            return id
+        }
 
-        override suspend fun getLatestBalance(bankName: String, accountLast4: String): AccountBalanceEntity? = null
+        override suspend fun getLatestBalance(bankName: String, accountLast4: String): AccountBalanceEntity? {
+            return latestBalances[accountKey(bankName, accountLast4)]
+        }
 
         override suspend fun getAccountLast4sEndingWith(bankName: String, suffix: String): List<String> {
             suffixLookupCount++
             return suffixMatches[bankName]?.get(suffix).orEmpty()
         }
 
+        override suspend fun getLatestBalanceOnOrBefore(
+            bankName: String,
+            accountLast4: String,
+            timestamp: LocalDateTime
+        ): AccountBalanceEntity? = balanceAtOrBefore
+
+        override suspend fun getBalancesAfterWithTransactions(
+            bankName: String,
+            accountLast4: String,
+            timestamp: LocalDateTime
+        ): List<AccountBalanceTransactionInfo> = balancesAfter
+
         override fun getLatestBalanceFlow(
             bankName: String,
             accountLast4: String
-        ): Flow<AccountBalanceEntity?> = flowOf(null)
+        ): Flow<AccountBalanceEntity?> = flowOf(latestBalances[accountKey(bankName, accountLast4)])
 
-        override fun getAllLatestBalances(): Flow<List<AccountBalanceEntity>> = flowOf(emptyList())
+        override fun getAllLatestBalances(): Flow<List<AccountBalanceEntity>> = flowOf(latestBalances.values.toList())
 
-        override fun getAllBalances(): Flow<List<AccountBalanceEntity>> = flowOf(emptyList())
+        override fun getAllBalances(): Flow<List<AccountBalanceEntity>> = flowOf(latestBalances.values.toList())
 
         override suspend fun deleteAllBalances() = Unit
 
@@ -112,7 +296,9 @@ class AccountBalanceRepositoryTest {
 
         override suspend fun deleteBalanceById(id: Long) = Unit
 
-        override suspend fun updateBalanceById(id: Long, newBalance: BigDecimal) = Unit
+        override suspend fun updateBalanceById(id: Long, newBalance: BigDecimal) {
+            updatedBalances[id] = newBalance
+        }
 
         override suspend fun getBalanceCountForAccount(bankName: String, accountLast4: String): Int = 0
 
@@ -125,5 +311,23 @@ class AccountBalanceRepositoryTest {
         ): Int = 0
 
         override suspend fun getAccountByLast4(accountLast4: String): AccountBalanceEntity? = null
+    }
+
+    private companion object {
+        fun accountKey(bankName: String, accountLast4: String) = "$bankName:$accountLast4"
+
+        fun balance(
+            id: Long,
+            bankName: String,
+            accountLast4: String,
+            balance: BigDecimal,
+            timestamp: LocalDateTime
+        ) = AccountBalanceEntity(
+            id = id,
+            bankName = bankName,
+            accountLast4 = accountLast4,
+            balance = balance,
+            timestamp = timestamp
+        )
     }
 }

--- a/app/src/test/java/com/ritesh/cashiro/domain/usecase/AddTransactionUseCaseTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/domain/usecase/AddTransactionUseCaseTest.kt
@@ -388,8 +388,9 @@ class AddTransactionUseCaseTest {
         private var nextId = 1L
 
         override suspend fun insertTransaction(transaction: TransactionEntity): Long {
-            insertedTransactions.add(transaction)
-            return nextId++
+            val id = nextId++
+            insertedTransactions.add(transaction.copy(id = id))
+            return id
         }
 
         override suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? = null

--- a/app/src/test/java/com/ritesh/cashiro/domain/usecase/AddTransactionUseCaseTest.kt
+++ b/app/src/test/java/com/ritesh/cashiro/domain/usecase/AddTransactionUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.ritesh.cashiro.domain.usecase
 
 import android.content.ContextWrapper
 import com.ritesh.cashiro.data.database.dao.AccountBalanceDao
+import com.ritesh.cashiro.data.database.dao.AccountBalanceTransactionInfo
 import com.ritesh.cashiro.data.database.dao.SubscriptionDao
 import com.ritesh.cashiro.data.database.dao.TransactionDao
 import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
@@ -511,6 +512,21 @@ class AddTransactionUseCaseTest {
         }
 
         override suspend fun getAccountLast4sEndingWith(bankName: String, suffix: String): List<String> = emptyList()
+        override suspend fun getLatestBalanceOnOrBefore(
+            bankName: String,
+            accountLast4: String,
+            timestamp: LocalDateTime
+        ): AccountBalanceEntity? {
+            val key = Pair(bankName, accountLast4)
+            return balances[key]
+                ?.filter { !it.timestamp.isAfter(timestamp) }
+                ?.maxByOrNull { it.timestamp }
+        }
+        override suspend fun getBalancesAfterWithTransactions(
+            bankName: String,
+            accountLast4: String,
+            timestamp: LocalDateTime
+        ): List<AccountBalanceTransactionInfo> = emptyList()
         override fun getLatestBalanceFlow(bankName: String, accountLast4: String): Flow<AccountBalanceEntity?> = flowOf(null)
         override fun getAllLatestBalances(): Flow<List<AccountBalanceEntity>> = flowOf(emptyList())
         override fun getAllBalances(): Flow<List<AccountBalanceEntity>> = flowOf(emptyList())


### PR DESCRIPTION
## Summary
- calculate SMS transaction balance rows from the latest account balance at or before the transaction timestamp
- recalculate later calculated transaction balance rows forward after inserting a backdated transaction
- preserve explicit SMS balances and manual balance rows as recalculation boundaries

Fixes #106

## Tests
- `./gradlew :app:testStandardDebugUnitTest --tests 'com.ritesh.cashiro.data.repository.AccountBalanceRepositoryTest' --no-configuration-cache`\n- `./gradlew :app:compileStandardDebugKotlin --no-configuration-cache`\n\n## Notes\n- The first verification attempt ran Gradle tasks in parallel and corrupted the local generated KSP cache. I cleared only generated KSP build artifacts and reran the checks sequentially; both passed.\n- This PR is scoped to balance recalculation only. Short account suffix detection is handled separately in #107 / #105.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Balance updates now use transaction details to calculate and store more accurate running balances.
  - Added support for looking up the latest balance at a specific time and viewing balance history with related transaction info.

- **Bug Fixes**
  - Improved balance handling for credit-card payments and income so calculations stay consistent.
  - Fixed balance updates to better preserve later changes when earlier transactions are inserted or adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->