### PR TITLE
FEAT: PDF Import Enhancements

### DIFF
--- a/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/database/dao/AccountBalanceDao.kt
@@ -390,7 +390,7 @@ abstract class AccountBalanceDao {
     /** Finds the latest account record for a given last-4 digits, regardless of bank name. */
     @Query("""
         SELECT * FROM account_balances
-        WHERE account_last4 = :accountLast4
+        WHERE account_last4 = :accountLast4 OR account_last4 LIKE '%' || :accountLast4
         ORDER BY timestamp DESC
         LIMIT 1
     """)

--- a/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
@@ -95,12 +95,12 @@ class GPayPdfParser : PdfStatementParser {
             // For Income: "Paid to [Bank] [Last4] [Amount]"
             val bankMatch = if (isIncome) {
                 Regex(
-                    """Paid to\s+(.+?)\s+(\d{4})(?=\s*[₹Rs])""",
+                    """Paid to\s+(.+?)\s+(\d{2,4})(?=\s*[₹Rs])""",
                     RegexOption.IGNORE_CASE
                 ).find(row)
             } else {
                 Regex(
-                    """Paid by\s+(.+?)\s+(\d{4})(?=\s*[₹Rs])""",
+                    """Paid by\s+(.+?)\s+(\d{2,4})(?=\s*[₹Rs])""",
                     RegexOption.IGNORE_CASE
                 ).find(row)
             }
@@ -284,7 +284,9 @@ class PhonePePdfParser : PdfStatementParser {
             // Clean up common prefixes that might leak into merchant
             merchant = merchant.replace(Regex("""^Paid to\s+""", RegexOption.IGNORE_CASE), "").trim()
             
-            val bankMatch = Regex("""(?:Credited to|Paid by)\s+\d*X+(\d{4})""").find(row)
+            // Extract account number: looks for "Credited to" or "Paid by" followed by something like "XX1234" or "XXXXXX12"
+            // Also supports shorter account suffixes (e.g., 2 digits)
+            val bankMatch = Regex("""(?:Credited to|Paid by|Account)\s*[:\s]*[0-9Xx]*X*(\d{2,4})\b""", RegexOption.IGNORE_CASE).find(row)
             val accountLast4 = bankMatch?.groupValues?.get(1)
             
             val transIdMatch = Regex("""Transact\s*ion\s+ID\s*[:\s]*([A-Z0-9]+)""", RegexOption.IGNORE_CASE).find(row)

--- a/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
+++ b/app/src/main/java/com/ritesh/cashiro/data/parser/pdf/PdfStatementParser.kt
@@ -8,11 +8,24 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
+/**
+ * Interface for PDF statement parsers that extract transactions from bank PDFs.
+ */
 interface PdfStatementParser {
+    /**
+     * Checks if this parser can handle the given PDF text.
+     */
     fun canHandle(text: String): Boolean
+
+    /**
+     * Parses the PDF text and returns a list of [ParsedTransaction]s.
+     */
     fun parse(text: String): List<ParsedTransaction>
 }
 
+/**
+ * Parser for GPay (Google Pay) transaction history PDF statements.
+ */
 class GPayPdfParser : PdfStatementParser {
     override fun canHandle(text: String): Boolean {
         val canHandle = (text.contains("GPay", ignoreCase = true) || text.contains("Google Pay", ignoreCase = true)) 
@@ -95,12 +108,12 @@ class GPayPdfParser : PdfStatementParser {
             // For Income: "Paid to [Bank] [Last4] [Amount]"
             val bankMatch = if (isIncome) {
                 Regex(
-                    """Paid to\s+(.+?)\s+(\d{2,4})(?=\s*[₹Rs])""",
+                    """Paid to\s+(.+?)\s+X*(\d{2,4})(?=\s*[₹Rs])""",
                     RegexOption.IGNORE_CASE
                 ).find(row)
             } else {
                 Regex(
-                    """Paid by\s+(.+?)\s+(\d{2,4})(?=\s*[₹Rs])""",
+                    """Paid by\s+(.+?)\s+X*(\d{2,4})(?=\s*[₹Rs])""",
                     RegexOption.IGNORE_CASE
                 ).find(row)
             }
@@ -148,6 +161,9 @@ class GPayPdfParser : PdfStatementParser {
 }
 
 
+/**
+ * Parser for PhonePe transaction history PDF statements.
+ */
 class PhonePePdfParser : PdfStatementParser {
     override fun canHandle(text: String): Boolean {
         val canHandle = text.contains("PhonePe", ignoreCase = true) || text.contains("Phone Pe", ignoreCase = true)
@@ -285,8 +301,9 @@ class PhonePePdfParser : PdfStatementParser {
             merchant = merchant.replace(Regex("""^Paid to\s+""", RegexOption.IGNORE_CASE), "").trim()
             
             // Extract account number: looks for "Credited to" or "Paid by" followed by something like "XX1234" or "XXXXXX12"
-            // Also supports shorter account suffixes (e.g., 2 digits)
-            val bankMatch = Regex("""(?:Credited to|Paid by|Account)\s*[:\s]*[0-9Xx]*X*(\d{2,4})\b""", RegexOption.IGNORE_CASE).find(row)
+            // Also supports shorter account suffixes (e.g., 2 digits). 
+            // Use non-greedy prefix to prevent capturing too few digits if 4 are available.
+            val bankMatch = Regex("""(?:Credited to|Paid by|Account)\s*[:\s]*[0-9Xx]*?X*(\d{2,4})\b""", RegexOption.IGNORE_CASE).find(row)
             val accountLast4 = bankMatch?.groupValues?.get(1)
             
             val transIdMatch = Regex("""Transact\s*ion\s+ID\s*[:\s]*([A-Z0-9]+)""", RegexOption.IGNORE_CASE).find(row)

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/cloudbackup/BackupSyncScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/cloudbackup/BackupSyncScreen.kt
@@ -1396,8 +1396,14 @@ fun BackupSyncScreen(
     dataPrivacyUiState.pdfAnalysisResult?.let { result ->
         PdfImportSheet(
             analysisResult = result,
-            onConfirm = { transactionDecisions, accountDecisions -> 
-                dataPrivacyViewModel.confirmPdfImport(accountDecisions, transactionDecisions)
+            availableAccounts = dataPrivacyUiState.availableAccounts,
+            onConfirm = { transactionDecisions, accountDecisions, accountMappings, shouldUpdateBalances ->
+                dataPrivacyViewModel.confirmPdfImport(
+                    accountDecisions = accountDecisions,
+                    accountMappings = accountMappings,
+                    transactionDecisions = transactionDecisions,
+                    shouldUpdateBalances = shouldUpdateBalances
+                )
             },
             onDismiss = { dataPrivacyViewModel.dismissPdfImport() }
         )

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyScreen.kt
@@ -80,7 +80,6 @@ import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class,
     ExperimentalHazeApi::class
@@ -90,17 +89,64 @@ fun DataPrivacyScreen(
     onNavigateBack: () -> Unit,
     onNavigateToAccounts: () -> Unit = {},
     appLockViewModel: AppLockViewModel = hiltViewModel(),
+    viewModel: DataPrivacyViewModel = hiltViewModel(),
     blurEffects: Boolean
 ) {
     val appLockUiState by appLockViewModel.uiState.collectAsStateWithLifecycle()
-    
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
     val hazeState = remember { HazeState() }
-    
+
     var showTimeoutDialog by remember { mutableStateOf(false) }
+    var showExportDialog by remember { mutableStateOf(false) }
+
+    // Launcher for selecting a backup file to import
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+        onResult = { uri ->
+            uri?.let { viewModel.importBackup(it) }
+        }
+    )
+
+    // Launcher for selecting a PDF statement to import
+    val pdfLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+        onResult = { uri ->
+            uri?.let { viewModel.analyzePdfStatement(it) }
+        }
+    )
+
+    // Launcher for saving the exported backup file
+    val exportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/json"),
+        onResult = { uri ->
+            uri?.let { viewModel.saveBackupToFile(it) }
+        }
+    )
+
+    // Handle import/export messages
+    LaunchedEffect(uiState.importExportMessage) {
+        uiState.importExportMessage?.let {
+            val result = snackbarHostState.showSnackbar(
+                message = it,
+                actionLabel = if (uiState.hasNewAccountsCreated) "View Accounts" else null
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                onNavigateToAccounts()
+            }
+            viewModel.clearImportExportMessage()
+        }
+    }
+
+    // Handle export success (trigger file saver)
+    LaunchedEffect(uiState.exportedBackupFile) {
+        uiState.exportedBackupFile?.let {
+            exportLauncher.launch("cashiro_backup_${System.currentTimeMillis()}.json")
+        }
+    }
 
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -210,12 +256,51 @@ fun DataPrivacyScreen(
                     }
                 }
 
+                // Data Management Section
+                SectionHeader(
+                    title = stringResource(R.string.data_management_section),
+                    modifier = Modifier.padding(start = Spacing.md, top = Spacing.md)
+                )
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(1.5.dp)
+                ) {
+                    ListItem(
+                        headline = { Text(stringResource(R.string.export_data)) },
+                        supporting = { Text(stringResource(R.string.export_data_sub)) },
+                        onClick = { showExportDialog = true },
+                        shape = ListItemPosition.Top.toShape(),
+                        padding = PaddingValues(0.dp)
+                    )
+                    ListItem(
+                        headline = { Text(stringResource(R.string.import_data)) },
+                        supporting = { Text(stringResource(R.string.import_data_sub)) },
+                        onClick = { importLauncher.launch(arrayOf("application/json")) },
+                        shape = ListItemPosition.Middle.toShape(),
+                        padding = PaddingValues(0.dp)
+                    )
+                    ListItem(
+                        headline = { Text(stringResource(R.string.import_pdf_statement)) },
+                        supporting = { Text(stringResource(R.string.import_pdf_statement_sub)) },
+                        trailing = {
+                            Icon(
+                                Icons.Rounded.PictureAsPdf,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
+                        onClick = { pdfLauncher.launch(arrayOf("application/pdf")) },
+                        shape = ListItemPosition.Bottom.toShape(),
+                        padding = PaddingValues(0.dp)
+                    )
+                }
+
                 // Add bottom spacing
                 Spacer(modifier = Modifier.size(Spacing.xl))
             }
         }
     }
-    
+
     // Timeout Dialog
     if (showTimeoutDialog) {
         val options = listOf(0, 1, 5, 15, 30)
@@ -241,7 +326,7 @@ fun DataPrivacyScreen(
                         ) {
                             RadioButton(
                                 selected = appLockUiState.timeoutMinutes == minutes,
-                                onClick = null 
+                                onClick = null
                             )
                             Text(
                                 text = when (minutes) {
@@ -293,6 +378,193 @@ fun DataPrivacyScreen(
                     ) else Modifier
                 ),
             shape = RoundedCornerShape(16.dp),
+        )
+    }
+
+    // Export Dialog
+    if (showExportDialog) {
+        ExportOptionsDialog(
+            onDismiss = { showExportDialog = false },
+            onConfirm = { config ->
+                viewModel.exportBackup(config)
+                showExportDialog = false
+            },
+            blurEffects = blurEffects,
+            hazeState = hazeState
+        )
+    }
+
+    // PDF Processing / Error dialog
+    if (uiState.isPdfProcessing || uiState.pdfProcessingError != null) {
+        PdfProcessingDialog(
+            isVisible = uiState.isPdfProcessing,
+            error = uiState.pdfProcessingError,
+            onDismissError = { viewModel.dismissPdfImport() },
+            blurEffects = blurEffects,
+            hazeState = hazeState
+        )
+    }
+
+    // PDF Import Review BottomSheet (Unified review of accounts and transactions)
+    uiState.pdfAnalysisResult?.let { result ->
+        PdfImportSheet(
+            analysisResult = result,
+            availableAccounts = uiState.availableAccounts,
+            onConfirm = { transactionDecisions, accountDecisions, accountMappings, shouldUpdateBalances ->
+                viewModel.confirmPdfImport(
+                    accountDecisions = accountDecisions,
+                    accountMappings = accountMappings,
+                    transactionDecisions = transactionDecisions,
+                    shouldUpdateBalances = shouldUpdateBalances
+                )
+            },
+            onDismiss = { viewModel.dismissPdfImport() }
+        )
+    }
+}
+
+@OptIn(ExperimentalHazeApi::class)
+@Composable
+fun ExportOptionsDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (BackupConfiguration) -> Unit,
+    blurEffects: Boolean ,
+    hazeState: HazeState = remember { HazeState() }
+) {
+    var includeTransactional by remember { mutableStateOf(true) }
+    var includeProfile by remember { mutableStateOf(true) }
+    var includeBudgets by remember { mutableStateOf(true) }
+    var includePreferences by remember { mutableStateOf(true) }
+    val containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.export_data)) },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    stringResource(R.string.select_data_to_backup),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                ExportCheckbox(stringResource(R.string.transactional_data), includeTransactional) { includeTransactional = it }
+                ExportCheckbox(stringResource(R.string.profile_data), includeProfile) { includeProfile = it }
+                ExportCheckbox(stringResource(R.string.budgets), includeBudgets) { includeBudgets = it }
+                ExportCheckbox(stringResource(R.string.app_preferences), includePreferences) { includePreferences = it }
+            }
+        },
+        confirmButton = {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    modifier = Modifier.align(Alignment.Center),
+                    horizontalArrangement = Arrangement.spacedBy(1.5.dp),
+                ) {
+                    Button(
+                        onClick = onDismiss,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.surface.copy(0.5f),
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        shape = RoundedCornerShape(
+                            topStart = Dimensions.Radius.xxl,
+                            topEnd = Dimensions.Radius.xs,
+                            bottomStart = Dimensions.Radius.xxl,
+                            bottomEnd = Dimensions.Radius.xs
+                        ),
+                        modifier = Modifier
+                            .padding(start = Spacing.xl)
+                            .weight(1f)
+                            .fillMaxWidth()
+                    ) {
+                        Text(
+                            text = stringResource(R.string.cancel),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                    Button(
+                        onClick = {
+                            onConfirm(
+                            BackupConfiguration(
+                                includeTransactionalData = includeTransactional,
+                                includeProfileData = includeProfile,
+                                includeBudgets = includeBudgets,
+                                includeAppPreferences = includePreferences
+                            ))},
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        ),
+                        shape = RoundedCornerShape(
+                            topStart = Dimensions.Radius.xs,
+                            topEnd = Dimensions.Radius.xxl,
+                            bottomStart = Dimensions.Radius.xs,
+                            bottomEnd = Dimensions.Radius.xxl
+                        ),
+                        modifier = Modifier
+                            .padding(end = Spacing.xl)
+                            .weight(1f)
+                            .fillMaxWidth()
+                    ) {
+                            Text(
+                                text = stringResource(R.string.export),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+
+                    }
+
+                }
+            }
+        },
+        containerColor = if (blurEffects)
+            MaterialTheme.colorScheme.surfaceContainerLow.copy(0.5f)
+        else MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier
+            .clip(RoundedCornerShape(16.dp))
+            .then(
+                if (blurEffects) Modifier.hazeEffect(
+                    state = hazeState,
+                    block = fun HazeEffectScope.() {
+                        style = HazeDefaults.style(
+                            backgroundColor = Color.Transparent,
+                            tint = HazeDefaults.tint(containerColor),
+                            blurRadius = 20.dp,
+                            noiseFactor = -1f,
+                        )
+                        blurredEdgeTreatment = BlurredEdgeTreatment.Unbounded
+                    }
+                ) else Modifier
+            ),
+        shape = RoundedCornerShape(16.dp),
+        dismissButton = {},
+
+    )
+}
+
+@Composable
+fun ExportCheckbox(
+    text: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange
+            ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CashiroCheckbox(checked = checked, onCheckedChange = null)
+        Text(
+            text = text,
+            modifier = Modifier.padding(start = 8.dp),
+            style = MaterialTheme.typography.bodyLarge
         )
     }
 }

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyScreen.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyScreen.kt
@@ -121,9 +121,13 @@ fun DataPrivacyScreen(
 
     // Launcher for saving the exported backup file
     val exportLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/json"),
+        contract = ActivityResultContracts.CreateDocument("application/zip"),
         onResult = { uri ->
-            uri?.let { viewModel.saveBackupToFile(it) }
+            if (uri != null) {
+                viewModel.saveBackupToFile(uri)
+            } else {
+                viewModel.clearExportedFile()
+            }
         }
     )
 
@@ -144,7 +148,7 @@ fun DataPrivacyScreen(
     // Handle export success (trigger file saver)
     LaunchedEffect(uiState.exportedBackupFile) {
         uiState.exportedBackupFile?.let {
-            exportLauncher.launch("cashiro_backup_${System.currentTimeMillis()}.json")
+            exportLauncher.launch("cashiro_backup_${System.currentTimeMillis()}.zip")
         }
     }
 
@@ -193,7 +197,7 @@ fun DataPrivacyScreen(
                     modifier = Modifier.padding(start = Spacing.md, top = Spacing.md))
                 Column(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(1.5.dp)
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
                     PreferenceSwitch(
                         title = stringResource(R.string.app_lock),
@@ -263,7 +267,7 @@ fun DataPrivacyScreen(
                 )
                 Column(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(1.5.dp)
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
                     ListItem(
                         headline = { Text(stringResource(R.string.export_data)) },
@@ -461,7 +465,7 @@ fun ExportOptionsDialog(
             ) {
                 Row(
                     modifier = Modifier.align(Alignment.Center),
-                    horizontalArrangement = Arrangement.spacedBy(1.5.dp),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
                     Button(
                         onClick = onDismiss,
@@ -553,7 +557,7 @@ fun ExportCheckbox(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 4.dp)
+            .padding(vertical = Spacing.xs)
             .toggleable(
                 value = checked,
                 onValueChange = onCheckedChange
@@ -563,7 +567,7 @@ fun ExportCheckbox(
         CashiroCheckbox(checked = checked, onCheckedChange = null)
         Text(
             text = text,
-            modifier = Modifier.padding(start = 8.dp),
+            modifier = Modifier.padding(start = Spacing.sm),
             style = MaterialTheme.typography.bodyLarge
         )
     }

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyUiState.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyUiState.kt
@@ -50,5 +50,6 @@ data class DataPrivacyUiState(
     val isPdfProcessing: Boolean = false,
     val pdfAnalysisResult: PdfAnalysisResult? = null,
     val pdfProcessingError: String? = null,
-    val hasNewAccountsCreated: Boolean = false
+    val hasNewAccountsCreated: Boolean = false,
+    val availableAccounts: List<AccountBalanceEntity> = emptyList()
 )

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyUiState.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyUiState.kt
@@ -19,20 +19,32 @@ data class PdfAnalysisResult(
     val accountMatches: List<PdfAccountMatch>
 )
 
+/**
+ * Wrapper for a parsed transaction with enrichment for the import review process.
+ */
 data class PdfTransactionImportItem(
     val parsed: com.ritesh.parser.core.ParsedTransaction,
     val duplicateMatch: TransactionEntity? = null,
     val initialDecision: TransactionImportDecision = if (duplicateMatch != null) TransactionImportDecision.SKIP else TransactionImportDecision.IMPORT_NEW
 )
 
+/**
+ * User's decision for a specific transaction being imported.
+ */
 enum class TransactionImportDecision { IMPORT_NEW, SKIP, OVERRIDE_EXISTING }
 
+/**
+ * Decision options for how to handle an account found in a PDF.
+ */
 data class PdfAccountMatch(
     val last4: String,
     val bankNameInPdf: String,
     // Existing account in the DB that matches, or null if no match.
     val existingAccount: AccountBalanceEntity?
 ) {
+    /**
+     * Whether this account already exists in the local database.
+     */
     val hasExistingMatch: Boolean get() = existingAccount != null
 }
 
@@ -41,6 +53,9 @@ data class PdfAccountMatch(
  */
 enum class AccountImportDecision { MERGE_WITH_EXISTING, CREATE_NEW }
 
+/**
+ * UI State for the Data & Privacy settings screen.
+ */
 data class DataPrivacyUiState(
     val importExportMessage: String? = null,
     val exportedBackupFile: File? = null,

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyViewModel.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyViewModel.kt
@@ -13,6 +13,7 @@ import com.ritesh.cashiro.data.backup.BackupImporter
 import com.ritesh.cashiro.data.backup.ExportResult
 import com.ritesh.cashiro.data.backup.ImportResult
 import com.ritesh.cashiro.data.backup.ImportStrategy
+import com.ritesh.cashiro.data.database.CashiroDatabase
 import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.data.database.entity.TransactionEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
@@ -31,6 +32,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.File
@@ -38,8 +40,13 @@ import java.security.MessageDigest
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import androidx.room.withTransaction
 import javax.inject.Inject
 
+/**
+ * ViewModel for managing data privacy settings, import/export functionality,
+ * and PDF statement processing.
+ */
 @HiltViewModel
 class DataPrivacyViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -48,7 +55,8 @@ class DataPrivacyViewModel @Inject constructor(
     private val transactionRepository: TransactionRepository,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val ruleRepository: RuleRepository,
-    private val ruleEngine: RuleEngine
+    private val ruleEngine: RuleEngine,
+    private val database: CashiroDatabase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DataPrivacyUiState())
@@ -56,12 +64,20 @@ class DataPrivacyViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            accountBalanceRepository.getAllLatestBalances().collect { accounts ->
-                _uiState.update { it.copy(availableAccounts = accounts) }
-            }
+            accountBalanceRepository.getAllLatestBalances()
+                .catch { e ->
+                    Log.e("DataPrivacyViewModel", "Error fetching accounts", e)
+                    _uiState.update { it.copy(pdfProcessingError = "Failed to load accounts: ${e.message}") }
+                }
+                .collect { accounts ->
+                    _uiState.update { it.copy(availableAccounts = accounts) }
+                }
         }
     }
 
+    /**
+     * Triggers the backup export process with the given configuration.
+     */
     fun exportBackup(config: BackupConfiguration) {
         viewModelScope.launch {
             try {
@@ -84,6 +100,9 @@ class DataPrivacyViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Saves the exported backup file to the provided URI.
+     */
     fun saveBackupToFile(uri: Uri) {
         viewModelScope.launch {
             try {
@@ -104,6 +123,9 @@ class DataPrivacyViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Imports app data from a backup file at the provided URI.
+     */
     fun importBackup(uri: Uri) {
         viewModelScope.launch {
             try {
@@ -122,12 +144,18 @@ class DataPrivacyViewModel @Inject constructor(
         }
     }
     
+    /**
+     * Shares the current exported backup file via an intent.
+     */
     fun shareBackup() {
         _uiState.value.exportedBackupFile?.let { file ->
             shareBackupFile(file)
         }
     }
 
+    /**
+     * Internal helper to share a file.
+     */
     private fun shareBackupFile(file: File) {
         try {
             val uri = FileProvider.getUriForFile(
@@ -152,7 +180,9 @@ class DataPrivacyViewModel @Inject constructor(
         }
     }
     
-    //Parse the PDF and emit analysis result
+    /**
+     * Parses the PDF at the given URI and emits an analysis result for user review.
+     */
     fun analyzePdfStatement(uri: Uri) {
         viewModelScope.launch {
             try {
@@ -184,16 +214,15 @@ class DataPrivacyViewModel @Inject constructor(
                     throw Exception("No transactions found in this PDF. Please ensure you are importing a supported GPay or PhonePe statement.")
                 }
 
-                // Collect distinct account last-4 values from all transactions.
-                // If last4 is null, we use a placeholder to allow mapping.
-                val distinctLast4s = parsedTransactions.map { it.accountLast4 ?: "Unknown" }.distinct()
+                // Collect distinct account (bankName, last4) pairs from all transactions.
+                val distinctAccounts = parsedTransactions.map { it.bankName to (it.accountLast4 ?: "Unknown") }.distinct()
 
                 // For each distinct account, look up whether it exists in the app.
-                val accountMatches = distinctLast4s.map { last4 ->
+                val accountMatches = distinctAccounts.map { (bankName, last4) ->
                     val existing = if (last4 != "Unknown") accountBalanceRepository.getAccountByLast4(last4) else null
                     PdfAccountMatch(
                         last4 = last4,
-                        bankNameInPdf = parsedTransactions.firstOrNull { (it.accountLast4 ?: "Unknown") == last4 }?.bankName ?: "PhonePe",
+                        bankNameInPdf = bankName,
                         existingAccount = existing
                     )
                 }
@@ -260,6 +289,10 @@ class DataPrivacyViewModel @Inject constructor(
     }
 
 
+    /**
+     * Confirms the PDF import and commits selected transactions and account mappings
+     * to the database. Everything is wrapped in a transaction for atomicity.
+     */
     fun confirmPdfImport(
         accountDecisions: Map<String, AccountImportDecision>,
         accountMappings: Map<String, AccountBalanceEntity?>,
@@ -271,161 +304,171 @@ class DataPrivacyViewModel @Inject constructor(
             try {
                 _uiState.update { it.copy(isPdfProcessing = true) }
 
-                // Resolve/create account for each last4 based on user's decision.
-                val resolvedAccounts = mutableMapOf<String, Pair<String, String>>() // last4 → (bankName, last4)
-                val resolvedAccountEntities = mutableMapOf<String, AccountBalanceEntity>()
+                database.withTransaction {
+                    // Resolve/create account for each last4 based on user's decision.
+                    // Key is bankNameInPdf + last4 for composite identity.
+                    val resolvedAccounts = mutableMapOf<String, Pair<String, String>>() // key → (bankName, last4)
+                    val resolvedAccountEntities = mutableMapOf<String, AccountBalanceEntity>()
 
-                var newAccountsCreated = false
-                for (match in analysis.accountMatches) {
-                    val decision = accountDecisions[match.last4] ?: AccountImportDecision.MERGE_WITH_EXISTING
-                    
-                    if (decision == AccountImportDecision.MERGE_WITH_EXISTING) {
-                        val mappedAccount = accountMappings[match.last4] ?: match.existingAccount
-                        if (mappedAccount != null) {
-                            resolvedAccounts[match.last4] = mappedAccount.bankName to mappedAccount.accountLast4
-                            resolvedAccountEntities[match.last4] = mappedAccount
+                    // Find earliest transaction timestamp to use as initial balance time
+                    val firstTransactionTimestamp = analysis.transactionItems
+                        .filterIndexed { index, item -> (transactionDecisions[index] ?: item.initialDecision) != TransactionImportDecision.SKIP }
+                        .minOfOrNull { it.parsed.timestamp } ?: System.currentTimeMillis()
+                    val initialBalanceTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(firstTransactionTimestamp), ZoneId.systemDefault()).minusSeconds(1)
+
+                    var newAccountsCreated = false
+                    for (match in analysis.accountMatches) {
+                        val compositeKey = "${match.bankNameInPdf}|${match.last4}"
+                        val decision = accountDecisions[match.last4] ?: AccountImportDecision.MERGE_WITH_EXISTING
+                        
+                        if (decision == AccountImportDecision.MERGE_WITH_EXISTING) {
+                            val mappedAccount = accountMappings[match.last4] ?: match.existingAccount
+                            if (mappedAccount != null) {
+                                resolvedAccounts[compositeKey] = mappedAccount.bankName to mappedAccount.accountLast4
+                                resolvedAccountEntities[compositeKey] = mappedAccount
+                            } else {
+                                // Fallback to creating new if merge requested but no account selected/found
+                                val newAccount = AccountBalanceEntity(
+                                    bankName = match.bankNameInPdf,
+                                    accountLast4 = match.last4,
+                                    balance = java.math.BigDecimal.ZERO,
+                                    timestamp = initialBalanceTime,
+                                    sourceType = "PDF_IMPORT",
+                                    iconName = "type_finance_bank"
+                                )
+                                val existing = accountBalanceRepository.getLatestBalance(match.bankNameInPdf, match.last4)
+                                val accountToUse = if (existing == null) {
+                                    val id = accountBalanceRepository.insertBalance(newAccount)
+                                    newAccountsCreated = true
+                                    newAccount.copy(id = id)
+                                } else existing
+                                
+                                resolvedAccounts[compositeKey] = accountToUse.bankName to accountToUse.accountLast4
+                                resolvedAccountEntities[compositeKey] = accountToUse
+                            }
                         } else {
-                            // Fallback to creating new if merge requested but no account selected/found
+                            // Create a new account. If user explicitly chose CREATE_NEW, we create it.
+                            // To ensure it's separate even if suffix matches, we can append (PDF) to bank name if a collision exists.
+                            val existingCollision = accountBalanceRepository.getLatestBalance(match.bankNameInPdf, match.last4)
+                            val finalBankName = if (existingCollision != null) "${match.bankNameInPdf} (PDF)" else match.bankNameInPdf
+
                             val newAccount = AccountBalanceEntity(
-                                bankName = match.bankNameInPdf,
+                                bankName = finalBankName,
                                 accountLast4 = match.last4,
                                 balance = java.math.BigDecimal.ZERO,
-                                timestamp = LocalDateTime.now(),
+                                timestamp = initialBalanceTime,
                                 sourceType = "PDF_IMPORT",
                                 iconName = "type_finance_bank"
                             )
-                            val existing = accountBalanceRepository.getLatestBalance(match.bankNameInPdf, match.last4)
-                            val accountToUse = if (existing == null) {
-                                val id = accountBalanceRepository.insertBalance(newAccount)
-                                newAccountsCreated = true
-                                newAccount.copy(id = id)
-                            } else existing
                             
-                            resolvedAccounts[match.last4] = accountToUse.bankName to accountToUse.accountLast4
-                            resolvedAccountEntities[match.last4] = accountToUse
-                        }
-                    } else {
-                        // Create a new "PhonePe" account for this last4.
-                        val newAccount = AccountBalanceEntity(
-                            bankName = match.bankNameInPdf,
-                            accountLast4 = match.last4,
-                            balance = java.math.BigDecimal.ZERO,
-                            timestamp = LocalDateTime.now(),
-                            sourceType = "PDF_IMPORT",
-                            iconName = "type_finance_bank"
-                        )
-                        // Only insert if not already existing for that last4+bank combo.
-                        val existing = accountBalanceRepository.getLatestBalance(match.bankNameInPdf, match.last4)
-                        val accountToUse = if (existing == null) {
                             val id = accountBalanceRepository.insertBalance(newAccount)
                             newAccountsCreated = true
-                            newAccount.copy(id = id)
-                        } else existing
-                        
-                        resolvedAccounts[match.last4] = accountToUse.bankName to accountToUse.accountLast4
-                        resolvedAccountEntities[match.last4] = accountToUse
-                    }
-                }
-
-                var importedCount = 0
-                // Process transactions in chronological order (oldest first) to ensure balance recalculations are correct
-                val sortedItems = analysis.transactionItems
-                    .mapIndexed { index, item -> index to item }
-                    .sortedBy { it.second.parsed.timestamp }
-
-                sortedItems.forEach { (index, item) ->
-                    val decision = transactionDecisions[index] ?: item.initialDecision
-                    if (decision == TransactionImportDecision.SKIP) return@forEach
-
-                    val parsed = item.parsed
-
-                    // Handle Override logic: Delete existing transaction if it's a duplicate and user wants to override
-                    if (decision == TransactionImportDecision.OVERRIDE_EXISTING && item.duplicateMatch != null) {
-                        transactionRepository.deleteTransaction(item.duplicateMatch, hardDelete = true)
+                            val accountToUse = newAccount.copy(id = id)
+                            
+                            resolvedAccounts[compositeKey] = accountToUse.bankName to accountToUse.accountLast4
+                            resolvedAccountEntities[compositeKey] = accountToUse
+                        }
                     }
 
-                    val hash = generateHash(parsed.smsBody, parsed.amount.toString(), parsed.timestamp)
-                    
-                    // Check if already exists (incase another transaction in same PDF has same hash, though unlikely)
-                    if (transactionRepository.getTransactionByHash(hash) == null) {
-                        val key = parsed.accountLast4 ?: "Unknown"
-                        val resolved = resolvedAccounts[key]
-                        
-                        // Use the mapper to get a base entity with all fields (merchant normalization, category mapping, etc.)
-                        val baseTransaction = parsed.toEntity()
-                        
-                        val transaction = baseTransaction.copy(
-                            bankName = resolved?.first ?: baseTransaction.bankName,
-                            accountNumber = resolved?.second ?: baseTransaction.accountNumber,
-                            fromAccount = if (baseTransaction.transactionType != TransactionType.INCOME) (resolved?.second ?: baseTransaction.accountNumber) else null,
-                            toAccount = if (baseTransaction.transactionType == TransactionType.INCOME) (resolved?.second ?: baseTransaction.accountNumber) else null,
-                            transactionHash = hash
-                        )
+                    var importedCount = 0
+                    // Process transactions in chronological order (oldest first) to ensure balance recalculations are correct
+                    val sortedItems = analysis.transactionItems
+                        .mapIndexed { index, item -> index to item }
+                        .sortedBy { it.second.parsed.timestamp }
 
-                        // Apply rules to the transaction
-                        val activeRules = ruleRepository.getActiveRulesByType(transaction.transactionType)
+                    sortedItems.forEach { (index, item) ->
+                        val decision = transactionDecisions[index] ?: item.initialDecision
+                        if (decision == TransactionImportDecision.SKIP) return@forEach
 
-                        // Check if this transaction should be blocked
-                        val blockingRule = ruleEngine.shouldBlockTransaction(
-                            transaction,
-                            transaction.smsBody,
-                            activeRules
-                        )
+                        val parsed = item.parsed
 
-                        if (blockingRule != null) {
-                            Log.d("DataPrivacyViewModel", "Transaction blocked by rule: ${blockingRule.name}")
-                            return@forEach
+                        // Handle Override logic: Delete existing transaction if it's a duplicate and user wants to override
+                        if (decision == TransactionImportDecision.OVERRIDE_EXISTING && item.duplicateMatch != null) {
+                            transactionRepository.deleteTransaction(item.duplicateMatch, hardDelete = true)
                         }
 
-                        // Apply non-blocking rules
-                        val (entityWithRules, ruleApplications) = ruleEngine.evaluateRules(
-                            transaction,
-                            transaction.smsBody,
-                            activeRules
-                        )
+                        val hash = generateHash(parsed.smsBody, parsed.amount.toString(), parsed.timestamp)
+                        
+                        // Check if already exists (incase another transaction in same PDF has same hash, though unlikely)
+                        if (transactionRepository.getTransactionByHash(hash) == null) {
+                            val compositeKey = "${parsed.bankName}|${parsed.accountLast4 ?: "Unknown"}"
+                            val resolved = resolvedAccounts[compositeKey]
+                            
+                            // Use the mapper to get a base entity with all fields (merchant normalization, category mapping, etc.)
+                            val baseTransaction = parsed.toEntity()
+                            
+                            val transaction = baseTransaction.copy(
+                                bankName = resolved?.first ?: baseTransaction.bankName,
+                                accountNumber = resolved?.second ?: baseTransaction.accountNumber,
+                                fromAccount = if (baseTransaction.transactionType != TransactionType.INCOME) (resolved?.second ?: baseTransaction.accountNumber) else null,
+                                toAccount = if (baseTransaction.transactionType == TransactionType.INCOME) (resolved?.second ?: baseTransaction.accountNumber) else null,
+                                transactionHash = hash
+                            )
 
-                        val rowId = transactionRepository.insertTransaction(entityWithRules)
-                        if (rowId != -1L) {
-                            if (ruleApplications.isNotEmpty()) {
-                                // Update transactionId in ruleApplications before saving
-                                val applicationsWithId = ruleApplications.map { 
-                                    it.copy(transactionId = rowId.toString())
+                            // Apply rules to the transaction
+                            val activeRules = ruleRepository.getActiveRulesByType(transaction.transactionType)
+
+                            // Check if this transaction should be blocked
+                            val blockingRule = ruleEngine.shouldBlockTransaction(
+                                transaction,
+                                transaction.smsBody,
+                                activeRules
+                            )
+
+                            if (blockingRule != null) {
+                                Log.d("DataPrivacyViewModel", "Transaction blocked by rule: ${blockingRule.name}")
+                                return@forEach
+                            }
+
+                            // Apply non-blocking rules
+                            val (entityWithRules, ruleApplications) = ruleEngine.evaluateRules(
+                                transaction,
+                                transaction.smsBody,
+                                activeRules
+                            )
+
+                            val rowId = transactionRepository.insertTransaction(entityWithRules)
+                            if (rowId != -1L) {
+                                if (ruleApplications.isNotEmpty()) {
+                                    // Update transactionId in ruleApplications before saving
+                                    val applicationsWithId = ruleApplications.map { 
+                                        it.copy(transactionId = rowId.toString())
+                                    }
+                                    ruleRepository.saveRuleApplications(applicationsWithId)
                                 }
-                                ruleRepository.saveRuleApplications(applicationsWithId)
+
+                                // Handle balance update automatically for PDF imports
+                                val accountEntity = resolvedAccountEntities[compositeKey]
+
+                                if (accountEntity != null && shouldUpdateBalances) {
+                                    accountBalanceRepository.insertTransactionBalance(
+                                        bankName = accountEntity.bankName,
+                                        accountLast4 = accountEntity.accountLast4,
+                                        amount = entityWithRules.amount,
+                                        transactionType = entityWithRules.transactionType,
+                                        explicitBalance = null, // We don't have balance in PhonePe PDF usually, let it calculate
+                                        timestamp = entityWithRules.dateTime,
+                                        transactionId = rowId,
+                                        creditLimit = accountEntity.creditLimit,
+                                        isCreditCard = accountEntity.isCreditCard,
+                                        smsSource = sanitizeSmsBody("PDF Import: ${parsed.smsBody.take(200)}"),
+                                        currency = entityWithRules.currency
+                                    )
+                                }
+
+                                importedCount++
                             }
-
-                            // Handle balance update automatically for PDF imports
-                            val key = parsed.accountLast4 ?: "Unknown"
-                            val accountEntity = resolvedAccountEntities[key]
-
-                            if (accountEntity != null && shouldUpdateBalances) {
-                                accountBalanceRepository.insertTransactionBalance(
-                                    bankName = accountEntity.bankName,
-                                    accountLast4 = accountEntity.accountLast4,
-                                    amount = entityWithRules.amount,
-                                    transactionType = entityWithRules.transactionType,
-                                    explicitBalance = null, // We don't have balance in PhonePe PDF usually, let it calculate
-                                    timestamp = entityWithRules.dateTime,
-                                    transactionId = rowId,
-                                    creditLimit = accountEntity.creditLimit,
-                                    isCreditCard = accountEntity.isCreditCard,
-                                    smsSource = "PDF Import: ${parsed.smsBody.take(200)}",
-                                    currency = entityWithRules.currency
-                                )
-                            }
-
-                            importedCount++
                         }
                     }
-                }
 
-                _uiState.update {
-                    it.copy(
-                        isPdfProcessing = false,
-                        pdfAnalysisResult = null,
-                        importExportMessage = "Successfully imported $importedCount transactions from PDF!",
-                        hasNewAccountsCreated = newAccountsCreated
-                    )
+                    _uiState.update {
+                        it.copy(
+                            isPdfProcessing = false,
+                            pdfAnalysisResult = null,
+                            importExportMessage = "Successfully imported $importedCount transactions from PDF!",
+                            hasNewAccountsCreated = newAccountsCreated
+                        )
+                    }
                 }
             } catch (e: Exception) {
                 Log.e("DataPrivacyViewModel", "Error committing PDF import", e)
@@ -434,11 +477,16 @@ class DataPrivacyViewModel @Inject constructor(
         }
     }
 
-    // Dismiss the PDF import dialog without saving.
+    /**
+     * Dismisses the PDF import review bottom sheet and clears analysis results.
+     */
     fun dismissPdfImport() {
         _uiState.update { it.copy(isPdfProcessing = false, pdfAnalysisResult = null, pdfProcessingError = null) }
     }
 
+    /**
+     * Generates a unique MD5 hash for transaction deduplication.
+     */
     private fun generateHash(message: String, amount: String, timestamp: Long): String {
         val input = "$message$amount$timestamp"
         return MessageDigest.getInstance("MD5")
@@ -446,12 +494,30 @@ class DataPrivacyViewModel @Inject constructor(
             .joinToString("") { "%02x".format(it) }
     }
 
+    /**
+     * Clears any status message after it has been displayed.
+     */
     fun clearImportExportMessage() {
         _uiState.update { it.copy(importExportMessage = null, hasNewAccountsCreated = false) }
     }
     
+    /**
+     * Clears the temporary exported file from UI state.
+     */
     fun clearExportedFile() {
         _uiState.update { it.copy(exportedBackupFile = null) }
+    }
+
+    /**
+     * Sanitizes the SMS body by masking sensitive identifiers like full account suffixes
+     * or payment references to ensure they are not persisted in plain text where not needed.
+     */
+    private fun sanitizeSmsBody(body: String): String {
+        // Mask 12-digit UTR/transaction IDs
+        var sanitized = body.replace(Regex("""\b\d{12}\b"""), "XXXXXXXXXXXX")
+        // Mask typical UPI IDs or long numeric strings
+        sanitized = sanitized.replace(Regex("""\b\d{8,11}\b"""), "XXXXXXXX")
+        return sanitized
     }
 
     private fun extractUtr(text: String?): String? {

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyViewModel.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/DataPrivacyViewModel.kt
@@ -16,6 +16,7 @@ import com.ritesh.cashiro.data.backup.ImportStrategy
 import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.data.database.entity.TransactionEntity
 import com.ritesh.cashiro.data.database.entity.TransactionType
+import com.ritesh.cashiro.data.mapper.toEntity
 import com.ritesh.cashiro.data.parser.pdf.GPayPdfParser
 import com.ritesh.cashiro.data.parser.pdf.PhonePePdfParser
 import com.ritesh.cashiro.data.repository.AccountBalanceRepository
@@ -52,6 +53,14 @@ class DataPrivacyViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(DataPrivacyUiState())
     val uiState: StateFlow<DataPrivacyUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            accountBalanceRepository.getAllLatestBalances().collect { accounts ->
+                _uiState.update { it.copy(availableAccounts = accounts) }
+            }
+        }
+    }
 
     fun exportBackup(config: BackupConfiguration) {
         viewModelScope.launch {
@@ -176,14 +185,15 @@ class DataPrivacyViewModel @Inject constructor(
                 }
 
                 // Collect distinct account last-4 values from all transactions.
-                val distinctLast4s = parsedTransactions.mapNotNull { it.accountLast4 }.distinct()
+                // If last4 is null, we use a placeholder to allow mapping.
+                val distinctLast4s = parsedTransactions.map { it.accountLast4 ?: "Unknown" }.distinct()
 
                 // For each distinct account, look up whether it exists in the app.
                 val accountMatches = distinctLast4s.map { last4 ->
-                    val existing = accountBalanceRepository.getAccountByLast4(last4)
+                    val existing = if (last4 != "Unknown") accountBalanceRepository.getAccountByLast4(last4) else null
                     PdfAccountMatch(
                         last4 = last4,
-                        bankNameInPdf = parsedTransactions.firstOrNull { it.accountLast4 == last4 }?.bankName ?: "PhonePe",
+                        bankNameInPdf = parsedTransactions.firstOrNull { (it.accountLast4 ?: "Unknown") == last4 }?.bankName ?: "PhonePe",
                         existingAccount = existing
                     )
                 }
@@ -252,7 +262,9 @@ class DataPrivacyViewModel @Inject constructor(
 
     fun confirmPdfImport(
         accountDecisions: Map<String, AccountImportDecision>,
-        transactionDecisions: Map<Int, TransactionImportDecision>
+        accountMappings: Map<String, AccountBalanceEntity?>,
+        transactionDecisions: Map<Int, TransactionImportDecision>,
+        shouldUpdateBalances: Boolean
     ) {
         val analysis = _uiState.value.pdfAnalysisResult ?: return
         viewModelScope.launch {
@@ -261,12 +273,37 @@ class DataPrivacyViewModel @Inject constructor(
 
                 // Resolve/create account for each last4 based on user's decision.
                 val resolvedAccounts = mutableMapOf<String, Pair<String, String>>() // last4 → (bankName, last4)
+                val resolvedAccountEntities = mutableMapOf<String, AccountBalanceEntity>()
 
                 var newAccountsCreated = false
                 for (match in analysis.accountMatches) {
                     val decision = accountDecisions[match.last4] ?: AccountImportDecision.MERGE_WITH_EXISTING
-                    val accountPair: Pair<String, String> = if (decision == AccountImportDecision.MERGE_WITH_EXISTING && match.existingAccount != null) {
-                        match.existingAccount.bankName to match.last4
+                    
+                    if (decision == AccountImportDecision.MERGE_WITH_EXISTING) {
+                        val mappedAccount = accountMappings[match.last4] ?: match.existingAccount
+                        if (mappedAccount != null) {
+                            resolvedAccounts[match.last4] = mappedAccount.bankName to mappedAccount.accountLast4
+                            resolvedAccountEntities[match.last4] = mappedAccount
+                        } else {
+                            // Fallback to creating new if merge requested but no account selected/found
+                            val newAccount = AccountBalanceEntity(
+                                bankName = match.bankNameInPdf,
+                                accountLast4 = match.last4,
+                                balance = java.math.BigDecimal.ZERO,
+                                timestamp = LocalDateTime.now(),
+                                sourceType = "PDF_IMPORT",
+                                iconName = "type_finance_bank"
+                            )
+                            val existing = accountBalanceRepository.getLatestBalance(match.bankNameInPdf, match.last4)
+                            val accountToUse = if (existing == null) {
+                                val id = accountBalanceRepository.insertBalance(newAccount)
+                                newAccountsCreated = true
+                                newAccount.copy(id = id)
+                            } else existing
+                            
+                            resolvedAccounts[match.last4] = accountToUse.bankName to accountToUse.accountLast4
+                            resolvedAccountEntities[match.last4] = accountToUse
+                        }
                     } else {
                         // Create a new "PhonePe" account for this last4.
                         val newAccount = AccountBalanceEntity(
@@ -279,19 +316,26 @@ class DataPrivacyViewModel @Inject constructor(
                         )
                         // Only insert if not already existing for that last4+bank combo.
                         val existing = accountBalanceRepository.getLatestBalance(match.bankNameInPdf, match.last4)
-                        if (existing == null) {
-                            accountBalanceRepository.insertBalance(newAccount)
+                        val accountToUse = if (existing == null) {
+                            val id = accountBalanceRepository.insertBalance(newAccount)
                             newAccountsCreated = true
-                        }
-                        match.bankNameInPdf to match.last4
+                            newAccount.copy(id = id)
+                        } else existing
+                        
+                        resolvedAccounts[match.last4] = accountToUse.bankName to accountToUse.accountLast4
+                        resolvedAccountEntities[match.last4] = accountToUse
                     }
-                    resolvedAccounts[match.last4] = accountPair
                 }
 
                 var importedCount = 0
-                analysis.transactionItems.forEachIndexed { index, item ->
+                // Process transactions in chronological order (oldest first) to ensure balance recalculations are correct
+                val sortedItems = analysis.transactionItems
+                    .mapIndexed { index, item -> index to item }
+                    .sortedBy { it.second.parsed.timestamp }
+
+                sortedItems.forEach { (index, item) ->
                     val decision = transactionDecisions[index] ?: item.initialDecision
-                    if (decision == TransactionImportDecision.SKIP) return@forEachIndexed
+                    if (decision == TransactionImportDecision.SKIP) return@forEach
 
                     val parsed = item.parsed
 
@@ -304,21 +348,18 @@ class DataPrivacyViewModel @Inject constructor(
                     
                     // Check if already exists (incase another transaction in same PDF has same hash, though unlikely)
                     if (transactionRepository.getTransactionByHash(hash) == null) {
-                        val resolved = parsed.accountLast4?.let { resolvedAccounts[it] }
-                        val transaction = TransactionEntity(
-                            amount = parsed.amount,
-                            merchantName = parsed.merchant ?: "Unknown",
-                            category = "Miscellaneous",
-                            transactionType = when (parsed.type) {
-                                com.ritesh.parser.core.TransactionType.INCOME -> TransactionType.INCOME
-                                else -> TransactionType.EXPENSE
-                            },
-                            dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(parsed.timestamp), ZoneId.systemDefault()),
-                            smsBody = parsed.smsBody,
-                            bankName = resolved?.first ?: parsed.bankName,
-                            accountNumber = resolved?.second ?: parsed.accountLast4,
-                            transactionHash = hash,
-                            currency = parsed.currency
+                        val key = parsed.accountLast4 ?: "Unknown"
+                        val resolved = resolvedAccounts[key]
+                        
+                        // Use the mapper to get a base entity with all fields (merchant normalization, category mapping, etc.)
+                        val baseTransaction = parsed.toEntity()
+                        
+                        val transaction = baseTransaction.copy(
+                            bankName = resolved?.first ?: baseTransaction.bankName,
+                            accountNumber = resolved?.second ?: baseTransaction.accountNumber,
+                            fromAccount = if (baseTransaction.transactionType != TransactionType.INCOME) (resolved?.second ?: baseTransaction.accountNumber) else null,
+                            toAccount = if (baseTransaction.transactionType == TransactionType.INCOME) (resolved?.second ?: baseTransaction.accountNumber) else null,
+                            transactionHash = hash
                         )
 
                         // Apply rules to the transaction
@@ -333,7 +374,7 @@ class DataPrivacyViewModel @Inject constructor(
 
                         if (blockingRule != null) {
                             Log.d("DataPrivacyViewModel", "Transaction blocked by rule: ${blockingRule.name}")
-                            return@forEachIndexed
+                            return@forEach
                         }
 
                         // Apply non-blocking rules
@@ -351,8 +392,28 @@ class DataPrivacyViewModel @Inject constructor(
                                     it.copy(transactionId = rowId.toString())
                                 }
                                 ruleRepository.saveRuleApplications(applicationsWithId)
-                                Log.d("DataPrivacyViewModel", "Applied ${ruleApplications.size} rules to transaction")
                             }
+
+                            // Handle balance update automatically for PDF imports
+                            val key = parsed.accountLast4 ?: "Unknown"
+                            val accountEntity = resolvedAccountEntities[key]
+
+                            if (accountEntity != null && shouldUpdateBalances) {
+                                accountBalanceRepository.insertTransactionBalance(
+                                    bankName = accountEntity.bankName,
+                                    accountLast4 = accountEntity.accountLast4,
+                                    amount = entityWithRules.amount,
+                                    transactionType = entityWithRules.transactionType,
+                                    explicitBalance = null, // We don't have balance in PhonePe PDF usually, let it calculate
+                                    timestamp = entityWithRules.dateTime,
+                                    transactionId = rowId,
+                                    creditLimit = accountEntity.creditLimit,
+                                    isCreditCard = accountEntity.isCreditCard,
+                                    smsSource = "PDF Import: ${parsed.smsBody.take(200)}",
+                                    currency = entityWithRules.currency
+                                )
+                            }
+
                             importedCount++
                         }
                     }

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportDialogs.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportDialogs.kt
@@ -38,6 +38,9 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
 
 // Shows while the PDF is being analyzed (processing indicator).
+/**
+ * Dialog shown while a PDF is being processed or when an error occurs.
+ */
 @OptIn(ExperimentalHazeApi::class)
 @Composable
 fun PdfProcessingDialog(
@@ -134,6 +137,9 @@ fun PdfProcessingDialog(
 }
 
 
+/**
+ * A card for reviewing and selecting a decision for a bank account found in a PDF.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PdfAccountDecisionCard(
@@ -224,7 +230,6 @@ fun PdfAccountDecisionCard(
                 cardColor = subCardColor,
                 cardTextColor =  subCardTextColor,
                 onClick = { 
-                    onDecisionChanged(AccountImportDecision.MERGE_WITH_EXISTING)
                     showAccountPicker = true
                 }
             )
@@ -254,6 +259,7 @@ fun PdfAccountDecisionCard(
                 selectedAccount = selectedMapping,
                 onAccountSelected = {
                     onMappingChanged(it)
+                    onDecisionChanged(AccountImportDecision.MERGE_WITH_EXISTING)
                     showAccountPicker = false
                 },
                 showNoneOption = false

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportDialogs.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportDialogs.kt
@@ -1,5 +1,6 @@
 package com.ritesh.cashiro.presentation.ui.features.settings.dataprivacy
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.presentation.effects.overScrollVertical
 import com.ritesh.cashiro.presentation.ui.components.LoadingCircle
 import com.ritesh.cashiro.presentation.ui.icons.HierarchySquare3
@@ -132,12 +134,18 @@ fun PdfProcessingDialog(
 }
 
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PdfAccountDecisionCard(
     match: PdfAccountMatch,
+    availableAccounts: List<AccountBalanceEntity>,
     currentDecision: AccountImportDecision,
-    onDecisionChanged: (AccountImportDecision) -> Unit
+    selectedMapping: AccountBalanceEntity?,
+    onDecisionChanged: (AccountImportDecision) -> Unit,
+    onMappingChanged: (AccountBalanceEntity?) -> Unit
 ) {
+    var showAccountPicker by remember { mutableStateOf(false) }
+
     val cardColor = when (currentDecision) {
         AccountImportDecision.MERGE_WITH_EXISTING -> MaterialTheme.colorScheme.primaryContainer.copy(0.25f)
         AccountImportDecision.CREATE_NEW -> MaterialTheme.colorScheme.tertiaryContainer.copy(0.25f)
@@ -185,7 +193,13 @@ fun PdfAccountDecisionCard(
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
-                    if (match.existingAccount != null) {
+                    if (selectedMapping != null) {
+                        Text(
+                            text = "Linked to: ${selectedMapping.bankName} (${selectedMapping.accountLast4})",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = cardTextColor,
+                        )
+                    } else if (match.existingAccount != null) {
                         Text(
                             text = "Matches: ${match.existingAccount.bankName}",
                             style = MaterialTheme.typography.labelSmall,
@@ -202,51 +216,48 @@ fun PdfAccountDecisionCard(
             }
 
             // Decision options
-            if (match.hasExistingMatch) {
-                // Show both options
-                DecisionOption(
-                    selected = currentDecision == AccountImportDecision.MERGE_WITH_EXISTING,
-                    label = "Merge with ${match.existingAccount?.bankName}",
-                    description = "Link transactions to existing account",
-                    icon = Iconax.HierarchySquare3,
-                    cardColor = subCardColor,
-                    cardTextColor =  subCardTextColor,
-                    onClick = { onDecisionChanged(AccountImportDecision.MERGE_WITH_EXISTING) }
-                )
-                DecisionOption(
-                    selected = currentDecision == AccountImportDecision.CREATE_NEW,
-                    label = "Create new bank \"${match.bankNameInPdf}\"",
-                    description = "Add as a separate account",
-                    icon = Icons.Rounded.Add,
-                    cardColor = subCardColor,
-                    cardTextColor =  subCardTextColor,
-                    onClick = { onDecisionChanged(AccountImportDecision.CREATE_NEW) }
-                )
-            } else {
-                // Only CREATE_NEW available
-                Surface(
-                    shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.tertiaryContainer.copy(0.4f)
-                ) {
-                    Row(
-                        modifier = Modifier.padding(Spacing.sm).fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
-                    ) {
-                        Icon(
-                            Icons.Rounded.Add,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                            tint = MaterialTheme.colorScheme.tertiary
-                        )
-                        Text(
-                            text = "Will create new bank: \"${match.bankNameInPdf}\"",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onTertiaryContainer
-                        )
-                    }
+            DecisionOption(
+                selected = currentDecision == AccountImportDecision.MERGE_WITH_EXISTING,
+                label = if (selectedMapping != null) "Merge with ${selectedMapping.bankName}" else "Link to existing account",
+                description = if (selectedMapping != null) "Transactions will be added to this account" else "Select an account to link",
+                icon = Iconax.HierarchySquare3,
+                cardColor = subCardColor,
+                cardTextColor =  subCardTextColor,
+                onClick = { 
+                    onDecisionChanged(AccountImportDecision.MERGE_WITH_EXISTING)
+                    showAccountPicker = true
                 }
-            }
+            )
+            
+            DecisionOption(
+                selected = currentDecision == AccountImportDecision.CREATE_NEW,
+                label = "Create new bank \"${match.bankNameInPdf}\"",
+                description = "Add as a separate account",
+                icon = Icons.Rounded.Add,
+                cardColor = subCardColor,
+                cardTextColor =  subCardTextColor,
+                onClick = { 
+                    onDecisionChanged(AccountImportDecision.CREATE_NEW)
+                    onMappingChanged(null)
+                }
+            )
+        }
+    }
+
+    if (showAccountPicker) {
+        ModalBottomSheet(
+            onDismissRequest = { showAccountPicker = false },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ) {
+            com.ritesh.cashiro.presentation.ui.components.AccountSelectionSheet(
+                accounts = availableAccounts,
+                selectedAccount = selectedMapping,
+                onAccountSelected = {
+                    onMappingChanged(it)
+                    showAccountPicker = false
+                },
+                showNoneOption = false
+            )
         }
     }
 }

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportSheet.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportSheet.kt
@@ -79,6 +79,10 @@ import com.ritesh.parser.core.ParsedTransaction
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+/**
+ * A bottom sheet for reviewing and confirming transactions extracted from a PDF.
+ * Allows users to map accounts, handle duplicates, and toggle balance updates.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PdfImportSheet(

--- a/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportSheet.kt
+++ b/app/src/main/java/com/ritesh/cashiro/presentation/ui/features/settings/dataprivacy/PdfImportSheet.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -59,6 +60,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.ritesh.cashiro.data.database.entity.AccountBalanceEntity
 import com.ritesh.cashiro.data.database.entity.TransactionEntity
 import com.ritesh.cashiro.presentation.effects.BlurredAnimatedVisibility
 import com.ritesh.cashiro.presentation.effects.overScrollVertical
@@ -81,27 +83,45 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun PdfImportSheet(
     analysisResult: PdfAnalysisResult,
-    onConfirm: (transactionDecisions: Map<Int, TransactionImportDecision>, accountDecisions: Map<String, AccountImportDecision>) -> Unit,
+    availableAccounts: List<AccountBalanceEntity>,
+    onConfirm: (
+        transactionDecisions: Map<Int, TransactionImportDecision>,
+        accountDecisions: Map<String, AccountImportDecision>,
+        accountMappings: Map<String, AccountBalanceEntity?>,
+        shouldUpdateBalances: Boolean
+    ) -> Unit,
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     
-    // Decisions for accounts (reusing logic from dialog)
+    // Decisions for accounts
     val accountDecisions = remember(analysisResult) {
-        mutableStateMapOf<String, AccountImportDecision>().apply {
-            analysisResult.accountMatches.forEach { match ->
-                put(match.last4, if (match.hasExistingMatch) AccountImportDecision.MERGE_WITH_EXISTING else AccountImportDecision.CREATE_NEW)
-            }
+        val map = mutableStateMapOf<String, AccountImportDecision>()
+        analysisResult.accountMatches.forEach { match ->
+            map[match.last4] = if (match.hasExistingMatch) AccountImportDecision.MERGE_WITH_EXISTING else AccountImportDecision.CREATE_NEW
         }
+        map
     }
+
+    // Custom mappings (extracted last4 -> selected app account)
+    val accountMappings = remember(analysisResult) {
+        val map = mutableStateMapOf<String, AccountBalanceEntity?>()
+        analysisResult.accountMatches.forEach { match ->
+            map[match.last4] = match.existingAccount
+        }
+        map
+    }
+
+    // Global decision for balance updates (deduction logic)
+    var shouldUpdateBalances by remember { mutableStateOf(true) }
 
     // Decisions for transactions
     val transactionDecisions = remember(analysisResult) {
-        mutableStateMapOf<Int, TransactionImportDecision>().apply {
-            analysisResult.transactionItems.forEachIndexed { index, item ->
-                put(index, item.initialDecision)
-            }
+        val map = mutableStateMapOf<Int, TransactionImportDecision>()
+        analysisResult.transactionItems.forEachIndexed { index, item ->
+            map[index] = item.initialDecision
         }
+        map
     }
 
     var filterIndex by remember { mutableIntStateOf(0) } // 0: All, 1: Duplicates
@@ -213,12 +233,51 @@ fun PdfImportSheet(
                         }
                     }
                     
-                    items(analysisResult.accountMatches) { match ->
+                    items(analysisResult.accountMatches) { accountMatch ->
                         PdfAccountDecisionCard(
-                            match = match,
-                            currentDecision = accountDecisions[match.last4] ?: AccountImportDecision.CREATE_NEW,
-                            onDecisionChanged = { accountDecisions[match.last4] = it }
+                            match = accountMatch,
+                            availableAccounts = availableAccounts,
+                            currentDecision = accountDecisions[accountMatch.last4] ?: AccountImportDecision.CREATE_NEW,
+                            selectedMapping = accountMappings[accountMatch.last4],
+                            onDecisionChanged = { accountDecisions[accountMatch.last4] = it },
+                            onMappingChanged = { accountMappings[accountMatch.last4] = it }
                         )
+                    }
+
+                    item {
+                        Surface(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(16.dp))
+                                .clickable { shouldUpdateBalances = !shouldUpdateBalances },
+                            shape = RoundedCornerShape(16.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.1f))
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(Spacing.md),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = "Update Account Balances",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                    Text(
+                                        text = "Automatically adjust balances based on all imported transactions",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                Switch(
+                                    checked = shouldUpdateBalances,
+                                    onCheckedChange = { shouldUpdateBalances = it },
+                                )
+                            }
+                        }
                     }
 
                     // Transactions Section
@@ -429,7 +488,12 @@ fun PdfImportSheet(
 
                     Button(
                         onClick = { 
-                            onConfirm(transactionDecisions.toMap(), accountDecisions.toMap())
+                            onConfirm(
+                                transactionDecisions.toMap(),
+                                accountDecisions.toMap(),
+                                accountMappings.toMap(),
+                                shouldUpdateBalances
+                            )
                         },
                         modifier = Modifier
                             .weight(1.5f)


### PR DESCRIPTION
## Summary

This PR enhances the PDF statement import workflow by adding granular account mapping and balance update control. Users can now explicitly link bank accounts detected in PDFs to their existing app accounts via a bottom-sheet picker. Additionally, a new feature-local toggle allows users to choose whether the import should automatically adjust account balances. These changes ensure that even when balance updates are skipped, transactions are correctly associated with the mapped accounts, maintaining data integrity in the UI.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix
- [x] refactor: Code improvement (no behavior change)

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

1. Navigate to **Settings > Data & Privacy** and select **Import PDF Statement**.
2. Upload a supported GPay or PhonePe PDF statement.
3. In the review sheet, use the "Link to existing account" option to map a PDF account to a specific app account.
4. Toggle the "Update Account Balances" switch on or off and click **Import**.
5. Verify that transactions appear in the selected account's history and that the balance was only adjusted if the toggle was enabled.

## Breaking changes

- [x] No breaking changes

## Related issues

## Checklist

- [x] Focused PR (single purpose)
- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `./gradlew test` passes locally
- [ ] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added data export options to configure what’s included in backups.
  - Enhanced JSON/PDF import flows with confirmation and improved account linking.
  - PDF imports now let you link detected accounts to existing accounts or create new ones, with an option to update account balances during import.
- **Bug Fixes**
  - Improved parsing and matching of masked account numbers, supporting 2–4 trailing digits.
  - Improved recognition and matching when full account suffix details aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->